### PR TITLE
More fixes to release YAML.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,12 @@ vsspell_ignored_words_1c7003ec377c4bd9bb3c509d29770210 = File:.\IgnoredWords.dic
 
 # match VS generated formatting for MSBuild project files
 [*.*proj,*.props,*.targets]
+indent_style = space
+indent_size = 2
+tab_width = 2
+
+[*.yml,*.yaml]
+indent_style = space
 indent_size = 2
 tab_width = 2
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -6,8 +6,8 @@ defaults:
 # only comes into play on a PUSH of a tag to the repository
 on:
   push:
-  tags:
-    - 'v*'
+    tags:
+      - 'v*'
 
 env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -16,13 +16,13 @@ env:
 
 jobs:
   build_target:
-  runs-on: windows-latest
-  steps:
-    - name: Checkout Repo
-      uses: actions/checkout@v2
-      with:
-        persist-credentials: false
-        fetch-depth: 0
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
 
     - name: Build Source
       run: .\Build-All.ps1 -FullInit
@@ -30,7 +30,7 @@ jobs:
     - name: Publish Artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: Nuget Packages
+        name: nuget-packages
         path: .\BuildOutput\Nuget
 
     - name: Show asset names
@@ -46,6 +46,3 @@ jobs:
         tag_name: ${{ github.ref }}
         release_name: Release ${{ github.ref }}
         draft: true
-        prerelease: false
-
-

--- a/src/Ubiquity.NET.Versioning.slnx
+++ b/src/Ubiquity.NET.Versioning.slnx
@@ -1,5 +1,8 @@
 <Solution>
   <Folder Name="/Solution Items/">
+    <File Path="../.editorconfig" />
+    <File Path="../.gitattributes" />
+    <File Path="../.gitignore" />
     <File Path="../Build-All.ps1" />
     <File Path="../BuildVersion.xml" />
     <File Path="../Directory.Build.props" />


### PR DESCRIPTION
More fixes to release YAML.
- Sadly, GH still has no way to validate the syntax of an action YAML before it is used.