### PR TITLE
Re-write to support testable projects

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -85,18 +85,14 @@ csharp_style_expression_bodied_constructors = false:error
 csharp_style_expression_bodied_lambdas = true:warning
 csharp_style_expression_bodied_local_functions = true:suggestion
 dotnet_diagnostic.RECS0001.severity = error
-dotnet_diagnostic.SA1023.severity = none
-dotnet_diagnostic.SA1124.severity = none
 csharp_style_allow_embedded_statements_on_same_line_experimental = false:error
-dotnet_diagnostic.SA1512.severity = none
-dotnet_diagnostic.SA1129.severity = error
 csharp_style_prefer_null_check_over_type_check = true:error
 csharp_prefer_simple_default_expression = true:error
 csharp_space_between_method_declaration_parameter_list_parentheses = true
 csharp_space_between_method_declaration_empty_parameter_list_parentheses = true
-dotnet_diagnostic.SA0001.severity = none
 csharp_style_unused_value_assignment_preference = discard_variable:suggestion
 csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+dotnet_diagnostic.SA1005.severity = none
 
 # Analysis and refactoring rules for Ubiquity.NET
 # Description: Code analysis rules for Ubiquity.NET projects
@@ -105,6 +101,72 @@ csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimenta
 
 # Code files
 [*.{cs,vb}]
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_coalesce_expression = true:warning
+dotnet_style_null_propagation = true:warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:error
+dotnet_style_prefer_auto_properties = true:error
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:warning
+dotnet_style_prefer_simplified_boolean_expressions = true:error
+dotnet_style_prefer_conditional_expression_over_assignment = true:warning
+dotnet_style_prefer_conditional_expression_over_return = true:warning
+dotnet_style_explicit_tuple_names = true:warning
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:error
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_diagnostic.MSTEST0032.severity = none
+dotnet_code_quality_unused_parameters = all:suggestion
 
 # IDE0059: Unnecessary assignment of a value
 dotnet_diagnostic.IDE0059.severity = none
@@ -1260,7 +1322,7 @@ dotnet_diagnostic.RECS0147.severity = warning
 
 dotnet_diagnostic.RECS0154.severity = suggestion
 
-dotnet_diagnostic.SA0001.severity = silent
+dotnet_diagnostic.SA0001.severity = none
 
 dotnet_diagnostic.SA1000.severity = none
 
@@ -1281,6 +1343,8 @@ dotnet_diagnostic.SA1014.severity = none
 dotnet_diagnostic.SA1015.severity = none
 
 dotnet_diagnostic.SA1021.severity = none
+
+dotnet_diagnostic.SA1023.severity = none
 
 dotnet_diagnostic.SA1024.severity = error
 
@@ -1318,11 +1382,15 @@ dotnet_diagnostic.SA1121.severity = none
 
 dotnet_diagnostic.SA1123.severity = error
 
+dotnet_diagnostic.SA1124.severity = none
+
 dotnet_diagnostic.SA1125.severity = suggestion
 
 dotnet_diagnostic.SA1127.severity = error
 
 dotnet_diagnostic.SA1128.severity = error
+
+dotnet_diagnostic.SA1129.severity = error
 
 dotnet_diagnostic.SA1130.severity = error
 
@@ -1442,6 +1510,8 @@ dotnet_diagnostic.SA1510.severity = error
 
 dotnet_diagnostic.SA1511.severity = error
 
+dotnet_diagnostic.SA1512.severity = none
+
 dotnet_diagnostic.SA1513.severity = error
 
 dotnet_diagnostic.SA1514.severity = error
@@ -1510,11 +1580,11 @@ dotnet_diagnostic.SA1634.severity = error
 
 dotnet_diagnostic.SA1635.severity = error
 
-dotnet_diagnostic.SA1636.severity = error
+dotnet_diagnostic.SA1636.severity = warning
 
-dotnet_diagnostic.SA1637.severity = silent
+dotnet_diagnostic.SA1637.severity = warning
 
-dotnet_diagnostic.SA1638.severity = silent
+dotnet_diagnostic.SA1638.severity = error
 
 dotnet_diagnostic.SA1640.severity = error
 
@@ -1534,72 +1604,3 @@ dotnet_diagnostic.SA1652.severity = warning
 
 dotnet_diagnostic.SX1101.severity = error
 
-# CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = none
-
-[*.{cs,vb}]
-#### Naming styles ####
-
-# Naming rules
-
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
-
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
-
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
-
-# Symbol specifications
-
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
-
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
-
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
-
-# Naming styles
-
-dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
-dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-dotnet_style_coalesce_expression = true:warning
-dotnet_style_null_propagation = true:warning
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:error
-dotnet_style_prefer_auto_properties = true:error
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:warning
-dotnet_style_prefer_simplified_boolean_expressions = true:error
-dotnet_style_prefer_conditional_expression_over_assignment = true:warning
-dotnet_style_prefer_conditional_expression_over_return = true:warning
-dotnet_style_explicit_tuple_names = true:warning
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_compound_assignment = true:error
-dotnet_style_prefer_simplified_interpolation = true:suggestion
-dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
-dotnet_style_namespace_match_folder = true:suggestion
-dotnet_diagnostic.MSTEST0032.severity = none
-dotnet_code_quality_unused_parameters = all:suggestion

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,12 +33,10 @@ jobs:
       - name: Build Source
         run: ./Build-All.ps1 -ForceClean
 
-      - name: Upload build logs
-        if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action/windows@v2
         with:
-            name: Build Logs
-            path: ./BuildOutput/BinLogs
+          files: BuildOutput/Test-Results/*.trx
 
       - name: Upload NuGET Packages
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -290,3 +290,4 @@ __pycache__/
 /_site
 /tools
 *.binlog
+/GeneratedVersion.props

--- a/BuildVersion.xml
+++ b/BuildVersion.xml
@@ -2,7 +2,7 @@
 This file is updated on a public release to set the next build that pre-releases will increment to
 -->
 <BuildVersionData
-    BuildMajor = "4"
+    BuildMajor = "5"
     BuildMinor = "0"
     BuildPatch = "0"
     PreReleaseName = "alpha"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,26 @@
 <Project>
-    <Import Project="$(MSBuildThisFileDirectory)src\Ubiquity.NET.Versioning.Build.Tasks\build\Ubiquity.NET.Versioning.Build.Tasks.props"/>
+    <!--
+    For local builds of this project in IDE ONLY
+    FORCE the Build Versioning Info as there is no lib to rely on; (This repo builds it!) and the automated build
+    scripts aren't used to build from within an IDE. Automated builds/Command line builds use the PowerShell
+    scripts to setup the variables for use in the build. This, handles the case of builds directly from the IDE
+    so that can complete a compilation.
+
+    Though, it should ONLY be used for local testing. Running the scripts locally from a command line is
+    the final best test of a given set of changes to the source.
+    -->
+    <PropertyGroup Condition="'$(BuildingInsideVisualStudio)'=='true'">
+        <!-- File Version for v5.0.0-alpha (See: https://csemver.org/playground/site/#/) [1.27597.27630.61954]-->
+        <!-- +1 to revision to account for CI build -->
+        <FileVersion>1.27597.27630.61955</FileVersion>
+        <PackageVersion>5.0.0-a.ci-4294967295.IDE</PackageVersion>
+        <ProductVersion>5.0.0-alpha.ci-4294967295.IDE</ProductVersion>
+        <AssemblyVersion>$(FileVersion)</AssemblyVersion>
+        <InformationalVersion>$(ProductVersion)</InformationalVersion>
+    </PropertyGroup>
+
+    <Import Condition="'$(BuildingInsideVisualStudio)'!='true'" Project="GeneratedVersion.props" />
+
     <!--
     Description:
         This property file is imported by the projects in this repository to set global locations
@@ -46,11 +67,8 @@
         <IsPullRequestBuild Condition="'$(IsPullRequestBuild)'==''">false</IsPullRequestBuild>
         <IsReleaseBuild Condition="'$(IsReleaseBuild)'==''">false</IsReleaseBuild>
         <BuildTime Condition="'$(BuildTime)'=='' AND '$(APPVEYOR_REPO_COMMIT_TIMESTAMP)'!=''">$(APPVEYOR_REPO_COMMIT_TIMESTAMP)</BuildTime>
-        <!--
-        Prevent importing of tasks that don't yet exist in this build, while still leveraging the rest of the infrastructure.
-        The build MUST set FullBuildNumber property for this to work.
-        -->
-        <BuildingCSemVerBuildTask>true</BuildingCSemVerBuildTask>
+        <!-- Disable defaulted, and sadly OPT-OUT, addition of GIT build Metadata to the informational version -->
+        <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     </PropertyGroup>
     <Choose>
         <!-- Apply standard properties for all C# projects -->
@@ -61,6 +79,7 @@
                 <Nullable>enable</Nullable>
                 <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
                 <EnableNETAnalyzers>true</EnableNETAnalyzers>
+                <UseStyleCop>true</UseStyleCop>
                 <!--
                 DO NOT ALLOW Implicit using msbuild feature - EVIL; causes mass issues and frustration moving code between projects when one doesn't
                 support it or uses a different framework version. Not to mention hiding the actual namespaces involved, making resolving conflicts HARDER.
@@ -68,13 +87,14 @@
                 <ImplicitUsings>disable</ImplicitUsings>
                 <!-- NOTE: Top-Level statements blocked as an error in .editorconfig and ImplicitUsings 'feature' VERIFIED in the targets file -->
             </PropertyGroup>
-            <!--<ItemGroup Condition="'$(NoCommonAnalyzers)'!='true'">
+            <ItemGroup Condition="'$(UseStyleCop)'=='true'">
                 <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
-            </ItemGroup>-->
+            </ItemGroup>
         </When>
         <When Condition="'$(MSBuildProjectExtension)'=='.vcxproj'">
             <!-- vcxproj uses a different pattern for output paths -->
             <PropertyGroup>
+                <UseStyleCop>false</UseStyleCop>
                 <OutputPath Condition="'$(OutputPath)'==''">$([MSBuild]::NormalizeDirectory("$(BaseOutputPath)", "$(Configuration)", "$(UnifiedPlatformPathName)"))</OutputPath>
                 <OutputPath>$([MSBuild]::EnsureTrailingSlash("$(OutputPath)"))</OutputPath>
                 <OutDir Condition="'$(OutDir)'==''">$(OutputPath)</OutDir>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,41 @@
-<Project>
-    <Import Project="$(MSBuildThisFileDirectory)src\Ubiquity.NET.Versioning.Build.Tasks\build\Ubiquity.NET.Versioning.Build.Tasks.targets"/>
+<Project InitialTargets="VerifyProjectSettings;ShowBuildParameters">
+    <Target Name="EnsureBuildOutputPaths" Condition="!EXISTS($(PackageOutputPath))" BeforeTargets="Build;Restore">
+        <MakeDir Directories="$(PackageOutputPath)"/>
+    </Target>
+
+    <Target Name="ShowBuildParameters">
+        <Message Importance="normal" Text="              BuildRootDir: $(BuildRootDir)" />
+        <Message Importance="normal" Text="       BaseBuildOutputPath: $(BaseBuildOutputPath)" />
+        <Message Importance="normal" Text="    BaseBuildOutputBinPath: $(BaseBuildOutputBinPath)" />
+        <Message Importance="normal" Text="BaseIntermediateOutputPath: $(BaseIntermediateOutputPath)" />
+        <Message Importance="normal" Text="                    IntDir: $(IntDir)" />
+        <Message Importance="normal" Text="            BaseOutputPath: $(BaseOutputPath)" />
+        <Message Importance="normal" Text="           FullBuildNumber: $(FullBuildNumber)"/>
+        <Message Importance="normal" Text="            PackageVersion: $(PackageVersion)"/>
+        <Message Importance="normal" Text="               FileVersion: $(FileVersion)"/>
+        <Message Importance="normal" Text="                  Platform: $(Platform)"/>
+        <Message Importance="normal" Text="             Configuration: $(Configuration)"/>
+    </Target>
+
+    <Target Name="VerifyProjectSettings" Condition="'$(MSBuildProjectExtension)'=='.csproj'">
+        <!--
+        Detect if something has this horrible non-feature enabled. It is a blight on the build/language that should never have been added
+        let alone used as the default for projects with no way to block/disable it all up...
+
+        NOTE:
+        .editorconfig in this repo includes `csharp_style_prefer_top_level_statements = false:error` to ensure that bad design choice isn't used either.
+
+        NOTE:
+        While the MSBuild `ImplicitUsings` property is banned from this repo, the C# language feature of global usings is NOT.
+        The build property will auto include an invisible and undiscoverable (without looking up obscure documentation)
+        set of namespaces that is NOT consistent or controlled by the developer. THAT is what is BAD/BROKEN about that feature.
+        By banning it's use and then providing a `GlobalNamespaceImports.cs` source file with ONLY global using statements ALL of
+        that is eliminated. Such use of the language feature restores FULL control and visibility of the namespaces to the developer,
+        where it belongs. For a good explanation of this problem see: https://rehansaeed.com/the-problem-with-csharp-10-implicit-usings/.
+        For an explanation of the benefits of the language feature see: https://www.hanselman.com/blog/implicit-usings-in-net-6
+        -->
+        <Error Condition="'$(ImplicitUsings)'!='disable'" Text="$(MSBuildProjectFile) - Projects in this repository MUST NOT have ImplicitUsings enabled!"/>
+
+        <Warning Condition="'$(BuildingInsideVisualStudio)' == 'true'" Text="!!! This is an IDE build-Version numbering is 'FAKED' !!!"/>
+    </Target>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
         to follow the rules is a recipe for failures. Automation is how that works. (With occasional overrides that should
         get the attention of a reviewer).
         -->
-    <!--<GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" Condition="'$(NoCommonAnalyzers)' != 'true'" />-->
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" Condition="'$(UseStyleCop)' != 'false'" />
   </ItemGroup>
   <!--
     Package versions made consistent across all packages referenced in this repository
@@ -20,10 +20,11 @@
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />
+    <PackageVersion Include="MSBuild.ProjectCreation" Version="14.0.5" />
     <!-- Tests all use the same framework versions -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.9.1" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.9.1" />
     <PackageVersion Include="Polyfill" Version="7.31.0" />
   </ItemGroup>
 </Project>

--- a/Invoke-Tests.ps1
+++ b/Invoke-Tests.ps1
@@ -34,10 +34,10 @@ try
     # as this assumes a build is already complete. This does NOT restore or build ANYTHING. It just
     # runs the tests.
     $buildInfo = Initialize-BuildEnvironment
-    Set-Location $buildInfo["SrcRootPath"]
+    Set-Location $buildInfo['SrcRootPath']
 
     # Just run the tests, everything should be built already; if not, then it is an error
-    dotnet test -s .runsettings -c $Configuration --no-build --no-restore
+    dotnet test -c $Configuration --results-directory $buildInfo['TestResultsPath'] --no-build --no-restore --logger 'trx;LogFilePrefix=TestResults'
 }
 catch
 {

--- a/Nuget.Config
+++ b/Nuget.Config
@@ -2,5 +2,6 @@
 <configuration>
     <packageSources>
         <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+        <add key="BuildOutput" value="BuildOutput\Nuget" />
     </packageSources>
 </configuration>

--- a/PsModules/RepoBuild/RepoBuild.pssproj
+++ b/PsModules/RepoBuild/RepoBuild.pssproj
@@ -52,6 +52,9 @@
     <Folder Include="Private\" />
     <Folder Include="Public\" />
   </ItemGroup>
+
+  <Target Name="VSTest"/>
+
   <!-- prevents NU1503 -->
   <Target Name="_IsProjectRestoreSupported"
           Returns="@(_ValidProjectsForRestore)">

--- a/src/.runsettings
+++ b/src/.runsettings
@@ -11,6 +11,6 @@ NOTE: Successful test runs will cleanup the subdirectory, but failed runs leave 
 -->
 <RunSettings>
   <RunConfiguration>
-    <ResultsDirectory>..\BuildOutput\Test-Output</ResultsDirectory>
+    <ResultsDirectory>..\BuildOutput\Test-Results</ResultsDirectory>
   </RunConfiguration>
 </RunSettings>

--- a/src/.runsettings
+++ b/src/.runsettings
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file provides overrides/settings for ALL tests in the solution IN THIS DIRECTORY!
+.runsettings file auto detection is VERY finicky. It must be named '.runsettings' [Exactly]
+AND it must exist as a sibling of the solution file in the FS hierarchy.
+
+Most importantly, it overrides the test output directory location to use a proper build
+output location. (Source tree is NOT polluted by test results!).
+
+NOTE: Successful test runs will cleanup the subdirectory, but failed runs leave it behind!
+-->
+<RunSettings>
+  <RunConfiguration>
+    <ResultsDirectory>..\BuildOutput\Test-Output</ResultsDirectory>
+  </RunConfiguration>
+</RunSettings>

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/CreateVersionInfo.cs
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/CreateVersionInfo.cs
@@ -1,34 +1,49 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="CreateVersionInfo.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
+// NOTE: Due to constraints, limitations and general issues with MSBUILD Tasks and dependency resolution
+//       This must NOT have any dependencies and therefore, does it all locally. This is not as complete
+//       as what is offered in the Ubiquity.NET.Versioning library but enables the tasks to function with
+//       the least of changes to the consumer (Update to package name and version, gets updated/corrected
+//       version)
+//
+// See: https://natemcmaster.com/blog/2017/11/11/msbuild-task-with-dependencies/
 namespace Ubiquity.NET.Versioning.Build.Tasks
 {
     public class CreateVersionInfo
         : Task
     {
         [Required]
-        public string? BuildMajor { get; set; }
+        public int BuildMajor { get; private set; }
 
         [Required]
-        public string? BuildMinor { get; set; }
+        public int BuildMinor { get; private set; }
 
         [Required]
-        public string? BuildPatch { get; set; }
+        public int BuildPatch { get; private set; }
 
-        public string? PreReleaseName { get; set; }
+        public string? PreReleaseName { get; private set; }
 
-        public string? PreReleaseNumber { get; set; }
+        public int PreReleaseNumber { get; private set; }
 
-        public string? PreReleaseFix { get; set; }
-
-        public string? CiBuildName { get; set; }
+        public int PreReleaseFix { get; private set; }
 
         public string? CiBuildIndex { get; set; }
+
+        public string? CiBuildName { get; set; }
 
         public string? BuildMeta { get; set; }
 
@@ -50,68 +65,208 @@ namespace Ubiquity.NET.Versioning.Build.Tasks
         [Output]
         public ushort? FileVersionRevision { get; set; }
 
-        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "External API invoker doesn't process exceptions")]
+        [SuppressMessage( "Design", "CA1031:Do not catch general exception types", Justification = "Caught exceptions are logged as errors" )]
         public override bool Execute( )
         {
             try
             {
-                if(PreReleaseName is null)
-                {
-                    Log.LogError("PreReleaseName is required");
-                }
+                Log.LogMessage(MessageImportance.High, $"+{nameof(CreateVersionInfo)} Task");
 
-                bool hasCiBuildIndex = CiBuildIndex is not null && string.IsNullOrWhiteSpace(CiBuildIndex);
-                bool hasCiBuildName = CiBuildIndex is not null && string.IsNullOrWhiteSpace(CiBuildIndex);
-                if (hasCiBuildIndex && !hasCiBuildName)
+                if(!ValidateInput())
                 {
-                    Log.LogError("CiBuildName must be provided when CiBuildIndex is");
-                }
-
-                if(!hasCiBuildIndex && hasCiBuildName)
-                {
-                    Log.LogError("Both CiBuildIndex must be provided if CiBuildName is");
-                }
-                // having both or NOT having both is perfectly OK.
-
-                // Stop if any errors detected in this task
-                if(Log.HasLoggedErrors)
-                {
+                    Log.LogError("Input validation failed");
                     return false;
                 }
 
-                var fmtProvider = CultureInfo.InvariantCulture;
-                var ciInfo = new CiBuildInfo(CiBuildIndex ?? string.Empty, CiBuildName ??string.Empty);
+                int preRelIndex = ComputePreReleaseIndex( PreReleaseName!);
+                Log.LogMessage(MessageImportance.High, "PreRelIndex={0}", preRelIndex);
 
-                PrereleaseVersion preReleaseVersion = default;
-                if(!string.IsNullOrWhiteSpace(PreReleaseName))
-                {
-                    preReleaseVersion = new PrereleaseVersion( PreReleaseName!
-                                                             , string.IsNullOrWhiteSpace( PreReleaseNumber ) ? 0 : Convert.ToInt32( PreReleaseNumber, fmtProvider)
-                                                             , string.IsNullOrWhiteSpace( PreReleaseFix ) ? 0 : Convert.ToInt32( PreReleaseFix, fmtProvider)
-                                                             );
-                }
+                CSemVer = CreateSemVerString( preRelIndex );
+                Log.LogMessage(MessageImportance.High, "CSemVer={0}", CSemVer ?? string.Empty);
 
-                var fullVersion = new CSemVer( Convert.ToInt32( BuildMajor, fmtProvider)
-                                             , Convert.ToInt32( BuildMinor, fmtProvider)
-                                             , Convert.ToInt32( BuildPatch, fmtProvider)
-                                             , preReleaseVersion
-                                             , ciInfo
-                                             , BuildMeta ?? string.Empty
-                                             );
+                ShortCSemVer = CreateSemVerString( preRelIndex, useShortForm: true );
+                Log.LogMessage(MessageImportance.High, "ShortCSemVer={0}", ShortCSemVer ?? string.Empty);
 
-                CSemVer = fullVersion.ToString( );
-                ShortCSemVer = fullVersion.ToString("MS", null);
-                FileVersionMajor = fullVersion.FileVersion.Major;
-                FileVersionMinor = fullVersion.FileVersion.Minor;
-                FileVersionBuild = fullVersion.FileVersion.Build;
-                FileVersionRevision = fullVersion.FileVersion.Revision;
+                SetFileVersion( preRelIndex );
                 return true;
             }
             catch(Exception ex)
             {
-                Log.LogErrorFromException(ex, showStackTrace: true);
+                Log.LogErrorFromException( ex, showStackTrace: true );
                 return false;
             }
+            finally
+            {
+                Log.LogMessage(MessageImportance.High, $"-{nameof(CreateVersionInfo)} Task");
+            }
         }
+
+        private string CreateSemVerString( int preRelIndex, bool useShortForm = false, bool includeMetadata = true )
+        {
+            bool alwaysIncludeZero = useShortForm;
+            var bldr = new StringBuilder()
+                          .AppendFormat(CultureInfo.InvariantCulture, "{0}.{1}.{2}", BuildMajor, BuildMinor, BuildPatch);
+
+            bool isPreRelease = preRelIndex >= 0;
+            if(isPreRelease)
+            {
+                bldr.Append( '-' )
+                    .Append( useShortForm ? PreReleaseShortNames[ preRelIndex ] : PreReleaseNames[ preRelIndex ] );
+
+                if(PreReleaseNumber > 0 || PreReleaseFix > 0 || alwaysIncludeZero)
+                {
+                    bldr.AppendFormat( CultureInfo.InvariantCulture, ".{0}", PreReleaseNumber );
+                    if(PreReleaseFix > 0 || alwaysIncludeZero)
+                    {
+                        bldr.AppendFormat( CultureInfo.InvariantCulture, ".{0}", PreReleaseFix );
+                    }
+                }
+            }
+
+            if(!string.IsNullOrWhiteSpace( CiBuildIndex ) && !string.IsNullOrWhiteSpace( CiBuildName ))
+            {
+                bldr.AppendFormat( CultureInfo.InvariantCulture, isPreRelease ? ".ci.{0}.{1}" : "--ci.{0}.{1}", CiBuildIndex, CiBuildName );
+            }
+
+            if(!string.IsNullOrWhiteSpace( BuildMeta ) && includeMetadata)
+            {
+                bldr.AppendFormat( CultureInfo.InvariantCulture, $"+{BuildMeta}" );
+            }
+
+            return bldr.ToString();
+        }
+
+        private void SetFileVersion( int preRelIndex )
+        {
+            UInt64 orderedVersion = ((ulong)BuildMajor * MulMajor) + ((ulong)BuildMinor * MulMinor) + (((ulong)BuildPatch + 1) * MulPatch);
+
+            if(preRelIndex >= 0)
+            {
+                orderedVersion -= MulPatch - 1; // Remove the fix+1 multiplier
+                orderedVersion += (ulong)preRelIndex * MulName;
+                orderedVersion += ((ulong)PreReleaseNumber) * MulNum;
+                orderedVersion += (ulong)PreReleaseFix;
+            }
+
+            Log.LogMessage(MessageImportance.High, "orderedVersion={0}", orderedVersion);
+
+            bool isCiBuild = !string.IsNullOrWhiteSpace(CiBuildIndex) && !string.IsNullOrWhiteSpace(CiBuildName);
+            UInt64 fileVersion64 = (orderedVersion << 1) + (isCiBuild ? 1ul : 0ul);
+            FileVersionRevision = (UInt16)(fileVersion64 % 65536);
+
+            UInt64 rem = (fileVersion64 - FileVersionRevision.Value) / 65536;
+            FileVersionBuild = (UInt16)(rem % 65536);
+
+            rem = (rem - FileVersionBuild.Value) / 65536;
+            FileVersionMinor = (UInt16)(rem % 65536);
+
+            rem = (rem - FileVersionMinor.Value) / 65536;
+            FileVersionMajor = (UInt16)(rem % 65536);
+
+            Log.LogMessage(MessageImportance.High, "FileVersionMajor={0}", FileVersionMajor);
+            Log.LogMessage(MessageImportance.High, "FileVersionMinor={0}", FileVersionMinor);
+            Log.LogMessage(MessageImportance.High, "FileVersionBuild={0}", FileVersionBuild);
+            Log.LogMessage(MessageImportance.High, "FileVersionRevision={0}", FileVersionRevision);
+        }
+
+        private bool ValidateInput( )
+        {
+            // Try to report as many input errors at once as is possible
+            // (That is, don't stop at first one - so all possible errors
+            bool hasInputError = false;
+            if(BuildMajor < 0 || BuildMajor > 99999)
+            {
+                Log.LogError( "BuildMajor value must be in range [0-99999]" );
+                hasInputError = true;
+            }
+
+            if(BuildMinor < 0 || BuildMinor > 49999)
+            {
+                Log.LogError( "BuildMinor value must be in range [0-49999]" );
+                hasInputError = true;
+            }
+
+            if(BuildPatch < 0 || BuildPatch > 9999)
+            {
+                Log.LogError( "BuildPatch value must be in range [0-99999]" );
+                hasInputError = true;
+            }
+
+            if(!string.IsNullOrWhiteSpace( PreReleaseName ))
+            {
+                if(!PreReleaseNames.Contains( PreReleaseName, StringComparer.InvariantCultureIgnoreCase ))
+                {
+                    if(!PreReleaseShortNames.Contains( PreReleaseName, StringComparer.InvariantCultureIgnoreCase ))
+                    {
+                        Log.LogError( "PreRelease Name is unknown" );
+                        hasInputError = true;
+                    }
+                }
+            }
+
+            if(PreReleaseNumber < 0 || PreReleaseNumber > 99)
+            {
+                Log.LogError( "PreReleaseNumber value must be in range [0-99]" );
+                hasInputError = true;
+            }
+
+            if(PreReleaseFix < 0 || PreReleaseFix > 99)
+            {
+                Log.LogError( "PreReleaseFix value must be in range [0-99]" );
+                hasInputError = true;
+            }
+
+            if(string.IsNullOrWhiteSpace( CiBuildIndex ) != string.IsNullOrWhiteSpace( CiBuildName ))
+            {
+                Log.LogError( "If CiBuildIndex is set then CiBuildName must also be set; If CiBuildIndex is NOT set then CiBuildName must not be set." );
+                hasInputError = true;
+            }
+
+            if(CiBuildIndex != null && !CiBuildIdRegEx.IsMatch( CiBuildIndex ))
+            {
+                Log.LogError( "CiBuildIndex does not match syntax defined by CSemVer" );
+                hasInputError = true;
+            }
+
+            if(CiBuildName != null && !CiBuildIdRegEx.IsMatch( CiBuildName ))
+            {
+                Log.LogError( "CiBuildName does not match syntax defined by CSemVer" );
+                hasInputError = true;
+            }
+
+            if(!string.IsNullOrEmpty( BuildMeta ) && BuildMeta!.Length > 20)
+            {
+                Log.LogError( "Build metadata, if provided, must not exceed 20 characters" );
+                hasInputError = true;
+            }
+
+            return !hasInputError;
+        }
+
+        private static int ComputePreReleaseIndex( string preRelName )
+        {
+            int index = Find( PreReleaseNames, preRelName ).Index;
+            return index >= 0 ? index : Find( PreReleaseShortNames, preRelName ).Index;
+        }
+
+        private static (string Value, int Index) Find( string[] values, string value )
+        {
+            var q = from element in values.Select( ( v, i ) => (Value: v, Index: i ) )
+                    where string.Equals( element.Value, value, StringComparison.OrdinalIgnoreCase )
+                    select element;
+
+            var result = q.FirstOrDefault();
+            return result == default ? (string.Empty, -1) : result;
+        }
+
+        private const ulong MulNum = 100;
+        private const ulong MulName = MulNum * 100;
+        private const ulong MulPatch = (MulName * 8) + 1;
+        private const ulong MulMinor = MulPatch * 10000;
+        private const ulong MulMajor = MulMinor * 50000;
+
+        private static readonly string[] PreReleaseNames = ["alpha", "beta", "delta", "epsilon", "gamma", "kappa", "prerelease", "rc"];
+        private static readonly string[] PreReleaseShortNames = ["a", "b", "d", "e", "g", "k", "p", "r"];
+        private static readonly Regex CiBuildIdRegEx = new(@"\A[0-9a-zA-Z\-]+\Z");
     }
 }

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/GetBuildIndexFromTime.cs
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/GetBuildIndexFromTime.cs
@@ -1,9 +1,16 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="GetBuildIndexFromTime.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Globalization;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
-namespace Ubiquity.NET.Versioning.Tasks
+namespace Ubiquity.NET.Versioning.Build.Tasks
 {
     public class GetBuildIndexFromTime
         : Task
@@ -16,8 +23,22 @@ namespace Ubiquity.NET.Versioning.Tasks
 
         public override bool Execute( )
         {
-            BuildIndex = new DateTimeOffset(TimeStamp.ToUniversalTime()).ToBuildIndex();
+            // establish an increasing build index based on the number of seconds from a common UTC date
+            var timeStamp = TimeStamp.ToUniversalTime( );
+
+            // Upper 16 bits of the build number is the number of days since the common base value
+            uint buildNumber = ((uint)(timeStamp - CommonBaseDate).Days) << 16;
+
+            // Lower 16 bits is the number of seconds (divided by 2) since midnight (on the date of the time stamp)
+            var midnightTodayUtc = new DateTime( timeStamp.Year, timeStamp.Month, timeStamp.Day, 0, 0, 0, DateTimeKind.Utc );
+            buildNumber += (ushort)((timeStamp - midnightTodayUtc).TotalSeconds / 2);
+            BuildIndex = buildNumber.ToString( CultureInfo.InvariantCulture );
             return true;
         }
+
+        // Fixed point in time to use as reference for a build index.
+        // Build index value is a string form of the number of days since this point in time + the number of seconds
+        // since midnight of that time stamp.
+        private static readonly DateTime CommonBaseDate = new( 2000, 1, 1, 0, 0, 0, DateTimeKind.Utc );
     }
 }

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/GlobalSuppressions.cs
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/GlobalSuppressions.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="GlobalSuppressions.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "MSBuild task library; Classes not documented" )]
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1636: The file header copyright text should match the copyright text from the settings.", Justification = "analyzer broken: See: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3271" )]
+
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1201", Justification = "Ordering from analyzer is brain dead stupid and doesn't allow customization" )]
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1202", Justification = "Ordering from analyzer is brain dead stupid and doesn't allow customization" )]
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1203", Justification = "Ordering from analyzer is brain dead stupid and doesn't allow customization" )]
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1204", Justification = "Ordering from analyzer is brain dead stupid and doesn't allow customization" )]
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1214", Justification = "Ordering from analyzer is brain dead stupid and doesn't allow customization" )]
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1215", Justification = "Ordering from analyzer is brain dead stupid and doesn't allow customization" )]

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/PackageReadMe.md
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/PackageReadMe.md
@@ -2,6 +2,22 @@
 The Ubiquity.NET.Versioning.Build.Tasks package provides automated support for build versioning
 using a Constrained Semantic Version ([CSemVer](https://csemver.org/)).
 
+>[!IMPORTANT]
+> As a [Breaking change in .NET SDK 8](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link)
+> is now forcing the build meta data for the Assembly Informational version without any user
+> consent. (A Highly controversial choice that was more easily handled via an OPT-IN pattern)
+> Unfortunately, this was set ON by default and made into an 'OPT-OUT' scenario. This library
+> will honor such a setting and does not alter/interfere with it in any way. (Though the results
+> can, unfortunately, produce surprising behavior).
+>
+> If you wish to disable this behavior you can set an MSBUILD property to OPT-OUT as follows:  
+> `<IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>`  
+>  
+> This is considered to have the least impact on those who are aware of the change and those who
+> use this library to set an explicit build meta data string. (Principle of least surprise for
+> what this library can control) 
+
+
 ## Overview
 Officially, NUGET Packages use a SemVer 2.0 (see http://semver.org).
 However, SemVer 2.0 doesn't consider or account for publicly available CI builds.

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/Ubiquity.NET.Versioning.Build.Tasks.csproj
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/Ubiquity.NET.Versioning.Build.Tasks.csproj
@@ -1,57 +1,28 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <!-- Consumed by MSBuild in VS which only builds on .NET Framework -->
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <!-- This "package" is Consumed by MSBuild in VS which only builds on .NET Framework -->
+        <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
+        <LangVersion>13</LangVersion>
         <Nullable>enable</Nullable>
-        <PackageId>Ubiquity.NET.Versioning.Build.Tasks</PackageId>
+
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>UbiquityDotNET</Authors>
-        <Copyright>Copyright (C) 2017-2020, Ubiquity.NET Contributors</Copyright>
+        <Copyright>Copyright (C) 2017-2025, Ubiquity.NET Contributors</Copyright>
         <Title>CSemVer Build version generator for MSBuild based builds</Title>
         <Description>Automatic build versioning with support for consistent build versioning across developer builds, CI builds and official release builds.</Description>
         <LicenseUrl>https://github.com/UbiquityDotNET/CSemVer.GitBuild/blob/master/LICENSE</LicenseUrl>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <!-- Specifies the location of the items built by this project in the generated package -->
-        <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
         <PackageProjectUrl>https://github.com/UbiquityDotNET/CSemVer.GitBuild</PackageProjectUrl>
         <RepositoryUrl>https://github.com/UbiquityDotNET/CSemVer.GitBuild</RepositoryUrl>
         <RepositoryType>GitHub</RepositoryType>
         <PackageTags>CSemVer;CI;SemVer</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
-        <LangVersion>13</LangVersion>
         <!-- [NU5100] By design, tasks are NOT placed in the "lib" folder of the package -->
-        <!-- [NU5128] Since the task is ONLY consumed by MSbuild, it is NOT using the lib folder, and therefore no TFM needs creation or labeling there -->
-        <NoWarn>NU5100, NU5128</NoWarn>
+        <NoWarn>NU5100</NoWarn>
+        <PackageReadmeFile>ReadMe.md</PackageReadmeFile>
+        <!-- Set output assembly into the "tasks" folder so it is usable as a "task"-->
+        <BuildOutputTargetFolder>tasks</BuildOutputTargetFolder>
+        <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     </PropertyGroup>
-    <!--
-    For local builds of this project in IDE, FORCE the BuildInfo as there is no lib to rely on; (This repo builds it!)
-    Automated builds/Command line builds use the PowerShell scripts to setup the variables for use in the build. This,
-    handles the case of builds directly from the IDE so that can complete a compilation. [Though, it should ONLY be
-    used for local testing. Running the scripts locally from a command line is the final best test of a given set of
-    changes to the source]
-    -->
-    <PropertyGroup Condition="'$(IsAutomatedBuild)' != 'true' AND '$(CiBuildIndex)'==''">
-        <CiBuildIndex>$([System.UInt32]::MaxValue)</CiBuildIndex>
-        <CiBuildName>IDE</CiBuildName>
-        <BuildMajor>4</BuildMajor>
-        <BuildMinor>0</BuildMinor>
-        <BuildPatch>0</BuildPatch>
-        <PreReleaseName>alpha</PreReleaseName>
-        <PreReleaseNumber>0</PreReleaseNumber>
-        <PreReleaseFix>0</PreReleaseFix>
-        <!-- File Version for v4.0.0.alpha (See: https://csemver.org/playground/site/#/) -->
-        <FileVersionMajor>1</FileVersionMajor>
-        <FileVersionMinor>8970</FileVersionMinor>
-        <FileVersionBuild>48319</FileVersionBuild>
-        <FileVersionRevision>10242</FileVersionRevision>
-        <FullBuildNumber>$(BuildMajor).$(BuildMinor).$(BuildPatch)-$(PreReleaseName).ci-ZZZ.$(CiBuildIndex)</FullBuildNumber>
-        <PackageVersion>$(BuildMajor).$(BuildMinor).$(BuildPatch)-a.ci-ZZZ.$(CiBuildIndex)</PackageVersion>
-    </PropertyGroup>
-
-    <ItemGroup>
-        <Content Include="build\**" PackagePath="build" />
-        <Content Include="buildMultiTargeting\**" PackagePath="buildMultiTargeting" />
-    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Build.Framework" PrivateAssets="All" />
@@ -59,13 +30,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <None Update="ReadMe.md">
-            <Pack>True</Pack>
-            <PackagePath>\</PackagePath>
-        </None>
-    </ItemGroup>
-
-    <ItemGroup>
-        <ProjectReference Include="..\Ubiquity.NET.Versioning\Ubiquity.NET.Versioning.csproj" PrivateAssets="All" />
+        <Content Include="PackageReadMe.md" PackagePath="ReadMe.md"/>
+        <Content Include="build\**" PackagePath="build"/>
+        <Content Include="buildMultiTargeting\**" PackagePath="buildMultiTargeting"/>
+        <!--<Content Include="_._" PackagePath="lib\net48"/>
+        <Content Include="_._" PackagePath="lib\netstandard2.0"/>-->
     </ItemGroup>
 </Project>

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.props
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.props
@@ -1,4 +1,4 @@
-﻿<Project TreatAsLocalProperty="TaskFolder">
+﻿<Project>
     <PropertyGroup>
         <!--
         Force the time-stamp into ISO 8601 format so it is locale neutral
@@ -7,16 +7,19 @@
         -->
         <BuildTime Condition="'$(BuildTime)'==''">$([System.DateTime]::UtcNow.ToString("o"))</BuildTime>
 
+        <!-- Default to a 'false' state if not defined or not true -->
+        <IsPullRequestBuild Condition="'$(IsPullRequestBuild)'!='true'">false</IsPullRequestBuild>
+        <IsAutomatedBuild Condition="'$(IsAutomatedBuild)'!='true'">false</IsAutomatedBuild>
+        <IsReleaseBuild Condition="'$(IsReleaseBuild)'!='true'">false</IsReleaseBuild>
+
         <!--
         While these names can be overridden it is important to keep in mind the sort ordering,
         ideally a local dev build should have a higher order than any other build (all other elements on
         the left being equal). This ensures that local edit, build, debug cycles are really using what was built.
         -->
-        <CiBuildName Condition="'$(CiBuildName)'=='' AND '$(IsPullRequestBuild)'=='true' AND '$(IsReleaseBuild)'!='true'">PRQ</CiBuildName>
-        <CiBuildName Condition="'$(CiBuildName)'=='' AND '$(IsAutomatedBuild)'=='true' AND '$(IsReleaseBuild)'!='true'">BLD</CiBuildName>
-        <CiBuildName Condition="'$(CiBuildName)'=='' AND '$(IsReleaseBuild)'!='true'">ZZZ</CiBuildName>
+        <CiBuildName Condition="'$(CiBuildName)'=='' AND $(IsPullRequestBuild) AND !$(IsReleaseBuild)">PRQ</CiBuildName>
+        <CiBuildName Condition="'$(CiBuildName)'=='' AND $(IsAutomatedBuild) AND !$(IsReleaseBuild)">BLD</CiBuildName>
+        <CiBuildName Condition="'$(CiBuildName)'=='' AND !$(IsReleaseBuild)">ZZZ</CiBuildName>
 
-        <TaskFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' ">netstandard2.0</TaskFolder>
-        <UbiquityDotNetVersioningBuildTasksAssembly>$(MSBuildThisFileDirectory)..\tasks\$(TaskFolder)\Ubiquity.NET.Versioning.Build.Tasks.dll</UbiquityDotNetVersioningBuildTasksAssembly>
     </PropertyGroup>
 </Project>

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.targets
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.targets
@@ -1,7 +1,13 @@
-﻿<Project>
-    <UsingTask TaskName="CreateVersionInfo" AssemblyFile="$(UbiquityDotNetVersioningBuildTasksAssembly)" Condition="'$(BuildingCSemVerBuildTask)'!='true'"/>
-    <UsingTask TaskName="GetBuildIndexFromTime" AssemblyFile="$(UbiquityDotNetVersioningBuildTasksAssembly)" Condition="'$(BuildingCSemVerBuildTask)'!='true'"/>
-    <UsingTask TaskName="ParseBuildVersionXml" AssemblyFile="$(UbiquityDotNetVersioningBuildTasksAssembly)" Condition="'$(BuildingCSemVerBuildTask)'!='true'"/>
+﻿<Project TreatAsLocalProperty="_TaskFolder;_Ubiquity_NET_Versioning_Build_Tasks;__FileVersion">
+    <PropertyGroup>
+        <_TaskFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' ">tasks\netstandard2.0\</_TaskFolder>
+        <_TaskFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' ">tasks\net48\</_TaskFolder>
+        <_Ubiquity_NET_Versioning_Build_Tasks>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\$(_TaskFolder)Ubiquity.NET.Versioning.Build.Tasks.dll))</_Ubiquity_NET_Versioning_Build_Tasks>
+    </PropertyGroup>
+
+    <UsingTask TaskName="CreateVersionInfo" AssemblyFile="$(_Ubiquity_NET_Versioning_Build_Tasks)"/>
+    <UsingTask TaskName="GetBuildIndexFromTime" AssemblyFile="$(_Ubiquity_NET_Versioning_Build_Tasks)"/>
+    <UsingTask TaskName="ParseBuildVersionXml" AssemblyFile="$(_Ubiquity_NET_Versioning_Build_Tasks)"/>
 
     <Target Name="PrepareVersioningForBuild"
             BeforeTargets="PrepareForBuild;_IntermediatePack"
@@ -9,8 +15,12 @@
             />
 
     <Target Name="GetRepositoryInfo">
-        <!-- Convert a time stamp into a usable CI Build index-->
-        <GetBuildIndexFromTime Condition="'$(CiBuildIndex)'==''"
+        <!--
+        Convert a time stamp into a usable CI Build index unless it is a release build.
+        By definition, a release build is NOT a CI build so it should not get a default
+        generated value for the index.
+        -->
+        <GetBuildIndexFromTime Condition="'$(CiBuildIndex)'=='' AND !$(IsReleaseBuild)"
                                TimeStamp="$(BuildTime)"
                                >
             <Output TaskParameter="BuildIndex" PropertyName="CiBuildIndex"/>
@@ -26,6 +36,10 @@
             <Output TaskParameter="PreReleaseNumber" PropertyName="PreReleaseNumber" />
             <Output TaskParameter="PreReleaseFix" PropertyName="PreReleaseFix" />
         </ParseBuildVersionXml>
+
+        <Error Condition="'$(BuildMajor)'==''" Code="CSM001" Text="BuildMajor is a required property, either set it as a global or in the build version XML"/>
+        <Error Condition="'$(BuildMinor)'==''" Code="CSM002" Text="BuildMinor is a required property, either set it as a global or in the build version XML"/>
+        <Error Condition="'$(BuildPatch)'==''" Code="CSM003" Text="BuildPatch is a required property, either set it as a global or in the build version XML"/>
 
         <!-- If FullBuildNumber not provided then generate version numbers/parts -->
         <CreateVersionInfo Condition ="'$(FullBuildNumber)'==''"
@@ -50,23 +64,24 @@
 
     <Target Name="SetVersionDependentProperties">
         <PropertyGroup>
-            <FileVersion Condition="'$(FileVersion)'==''">$(FileVersionMajor).$(FileVersionMinor).$(FileVersionBuild).$(FileVersionRevision)</FileVersion>
-            <AssemblyVersion>$(FileVersion)</AssemblyVersion>
-            <InformationalVersion>$(FullBuildNumber)</InformationalVersion>
+            <__FileVersion>$(FileVersionMajor).$(FileVersionMinor).$(FileVersionBuild).$(FileVersionRevision)</__FileVersion>
+            <FileVersion Condition="'$(FileVersion)'==''">$(__FileVersion)</FileVersion>
+            <AssemblyVersion Condition="'$(AssemblyVersion)'==''">$(__FileVersion)</AssemblyVersion>
+            <InformationalVersion Condition="$(InformationalVersion)==''">$(FullBuildNumber)</InformationalVersion>
         </PropertyGroup>
     </Target>
 
     <Target Name="VerifyProvidedBuildVersion" Condition="'$(FullBuildNumber)'!=''" >
-        <Error Condition="'$(FileVersionMajor)'==''" Text="FileVersionMajor property not found"/>
-        <Error Condition="'$(FileVersionMinor)'==''" Text="FileVersionMinor property not found"/>
-        <Error Condition="'$(FileVersionRevision)'==''" Text="FileVersionRevision property not found"/>
-        <Error Condition="'$(PackageVersion)'==''" Text="PackageVersion property not found"/>
+        <Error Condition="'$(FileVersionMajor)'==''" Code="CSM004" Text="FileVersionMajor property not found"/>
+        <Error Condition="'$(FileVersionMinor)'==''" Code="CSM005" Text="FileVersionMinor property not found"/>
+        <Error Condition="'$(FileVersionRevision)'==''" Code="CSM006" Text="FileVersionRevision property not found"/>
+        <Error Condition="'$(PackageVersion)'==''" Code="CSM007" Text="PackageVersion property not found"/>
     </Target>
 
-    <!-- Generates include header for native code Win32 Resource (.RC) -->
+    <!-- Generates include header for native code [Including Win32 Resource (.RC) ] -->
     <Target Name="GenerateVesionInfoHeader"
-            Condition="'$(MSBuildProjectExtension)'=='.vcxproj'"
-            BeforeTargets="ResourceCompile"
+            Condition="'$(MSBuildProjectExtension)'=='.vcxproj' AND '$(GeneratedVersionInfoHeader)'!=''"
+            BeforeTargets="ClCompile"
             >
         <ItemGroup>
             <VersionInfoGeneratedLine Include='#define FILE_VERSION_MAJOR $(FileVersionMajor)'/>
@@ -103,11 +118,5 @@
         <ItemGroup>
             <Compile Include="$(IntermediateOutputPath)AssemblyVersionInfo.g.cs"/>
         </ItemGroup>
-    </Target>
-
-    <Target Name="ShowBuildParams" BeforeTargets="Build;Pack">
-        <Message Importance="High" Text="FullBuildNumber: $(FullBuildNumber)"/>
-        <Message Importance="High" Text=" PackageVersion: $(PackageVersion)"/>
-        <Message Importance="High" Text="    FileVersion: $(FileVersion)"/>
     </Target>
 </Project>

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="CSemVerTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Runtime.CompilerServices;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -58,73 +64,73 @@ namespace Ubiquity.NET.Versioning.UT
             var ciInfo = new CiBuildInfo("BuildIndex", "BuildName");
 
             // Validate ToString(null, null); // same as ToString("M")
-            Assert.AreEqual("v20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString(null, null));
-            Assert.AreEqual("v20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("M", null));
-            Assert.AreEqual("v20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString());
+            Assert.AreEqual("20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString(null, null));
+            Assert.AreEqual("20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("M", null));
+            Assert.AreEqual("20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString());
 
             // Validate ToString("M") P=0; CI=0
-            Assert.AreEqual("v20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("M", null));
+            Assert.AreEqual("20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("M", null));
 
             // Validate ToString("M") P=0; CI=1
-            Assert.AreEqual("v20.1.4--ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, default, ciInfo, "buildMeta").ToString("M", null));
+            Assert.AreEqual("20.1.4--ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, default, ciInfo, "buildMeta").ToString("M", null));
 
             // Validate ToString("M") P=1; CI=0
-            Assert.AreEqual("v20.1.4-alpha+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("M", null));
-            Assert.AreEqual("v20.1.4-beta.1+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("M", null));
-            Assert.AreEqual("v20.1.4-delta.0.1+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("M", null));
+            Assert.AreEqual("20.1.4-alpha+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("M", null));
+            Assert.AreEqual("20.1.4-beta.1+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("M", null));
+            Assert.AreEqual("20.1.4-delta.0.1+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("M", null));
 
             // Validate ToString("M") P=1; CI=1
-            Assert.AreEqual("v20.1.4-alpha.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("M", null));
-            Assert.AreEqual("v20.1.4-beta.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("M", null));
-            Assert.AreEqual("v20.1.4-delta.0.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("M", null));
+            Assert.AreEqual("20.1.4-alpha.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("M", null));
+            Assert.AreEqual("20.1.4-beta.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("M", null));
+            Assert.AreEqual("20.1.4-delta.0.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("M", null));
 
             // Validate ToString("S") P=0; CI=0
-            Assert.AreEqual("v20.1.4", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("S", null));
 
             // Validate ToString("S") P=0; CI=1
-            Assert.AreEqual("v20.1.4--ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, default, ciInfo, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4--ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, default, ciInfo, "buildMeta").ToString("S", null));
 
             // Validate ToString("S") P=1; CI=0
-            Assert.AreEqual("v20.1.4-a", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("S", null));
-            Assert.AreEqual("v20.1.4-b.1", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("S", null));
-            Assert.AreEqual("v20.1.4-d.0.1", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-a", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-b.1", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-d.0.1", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("S", null));
 
             // Validate ToString("S") P=1; CI=1
-            Assert.AreEqual("v20.1.4-a.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("S", null));
-            Assert.AreEqual("v20.1.4-b.1.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("S", null));
-            Assert.AreEqual("v20.1.4-d.0.1.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-a.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-b.1.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-d.0.1.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("S", null));
 
             // Validate ToString("MS") P=0; CI=0
-            Assert.AreEqual("v20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("MS", null));
 
             // Validate ToString("S") P=0; CI=1
-            Assert.AreEqual("v20.1.4--ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, default, ciInfo, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4--ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, default, ciInfo, "buildMeta").ToString("MS", null));
 
             // Validate ToString("S") P=1; CI=0
-            Assert.AreEqual("v20.1.4-a+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("MS", null));
-            Assert.AreEqual("v20.1.4-b.1+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("MS", null));
-            Assert.AreEqual("v20.1.4-d.0.1+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-a+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-b.1+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-d.0.1+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("MS", null));
 
             // Validate ToString("S") P=1; CI=1
-            Assert.AreEqual("v20.1.4-a.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("MS", null));
-            Assert.AreEqual("v20.1.4-b.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("MS", null));
-            Assert.AreEqual("v20.1.4-d.0.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-a.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-b.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-d.0.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("MS", null));
 
             // Validate ToString("SM") P=0; CI=0
-            Assert.AreEqual("v20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("SM", null));
 
             // Validate ToString("S") P=0; CI=1
-            Assert.AreEqual("v20.1.4--ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, default, ciInfo, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4--ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, default, ciInfo, "buildMeta").ToString("SM", null));
 
             // Validate ToString("S") P=1; CI=0
-            Assert.AreEqual("v20.1.4-a+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("SM", null));
-            Assert.AreEqual("v20.1.4-b.1+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("SM", null));
-            Assert.AreEqual("v20.1.4-d.0.1+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-a+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-b.1+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-d.0.1+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("SM", null));
 
             // Validate ToString("S") P=1; CI=1
-            Assert.AreEqual("v20.1.4-a.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("SM", null));
-            Assert.AreEqual("v20.1.4-b.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("SM", null));
-            Assert.AreEqual("v20.1.4-d.0.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-a.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-b.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-d.0.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("SM", null));
         }
 
         [TestMethod]

--- a/src/Ubiquity.NET.Versioning.UT/CiBuildInfoTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CiBuildInfoTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="CiBuildInfoTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/src/Ubiquity.NET.Versioning.UT/DateTimeOffsetExtensionsTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/DateTimeOffsetExtensionsTests.cs
@@ -1,13 +1,19 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="DateTimeOffsetExtensionsTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ubiquity.NET.Versioning.UT
 {
-    [TestClass()]
+    [TestClass]
     public class DateTimeOffsetExtensionsTests
     {
-        [TestMethod()]
+        [TestMethod]
         public void ToBuildIndexTest( )
         {
             string index = DateTimeOffset.Now.ToBuildIndex();

--- a/src/Ubiquity.NET.Versioning.UT/FileVersionQuadTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/FileVersionQuadTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="FileVersionQuadTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -22,6 +28,7 @@ namespace Ubiquity.NET.Versioning.Tests
         {
             var x = new FileVersionQuad(0x1234, 0x5678, 0x9ABC, 0xDEF0 );
             UInt64 y = x.ToUInt64();
+
             // NOTE: Major contains the Most significant "16 bits" of the result
             //       Minor the next...
             Assert.AreEqual(0x123456789ABCDEF0ul, y);

--- a/src/Ubiquity.NET.Versioning.UT/ParsedBuildVersionXmlTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/ParsedBuildVersionXmlTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="ParsedBuildVersionXmlTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.IO;
 using System.Xml.Linq;
 
@@ -6,7 +12,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ubiquity.NET.Versioning.Tests
 {
-    [TestClass()]
+    [TestClass]
     public class ParsedBuildVersionXmlTests
     {
         [TestMethod]
@@ -21,7 +27,7 @@ namespace Ubiquity.NET.Versioning.Tests
             Assert.AreEqual(5, parsedData.PreReleaseFix);
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void ParseExtraAttributeShouldFail( )
         {
             var ex = Assert.ThrowsExactly<InvalidDataException>(
@@ -31,7 +37,7 @@ namespace Ubiquity.NET.Versioning.Tests
             Assert.AreEqual("Unexpected attribute foo", ex.Message);
         }
 
-        [TestMethod()]
+        [TestMethod]
         public void ParseEmptyDocShouldFail( )
         {
             var ex = Assert.ThrowsExactly<FormatException>(

--- a/src/Ubiquity.NET.Versioning.UT/PrereleaseVersionTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/PrereleaseVersionTests.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="PrereleaseVersionTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -74,6 +80,7 @@ namespace Ubiquity.NET.Versioning.Tests
 
             prv = new PrereleaseVersion( "beta", 1, 0);
             Assert.AreEqual("-b.1",prv.ToString("S", null));
+
             // The Z format is used when there is CI build info available
             Assert.AreEqual("-beta.1.0",prv.ToString("Z", null));
             Assert.AreEqual("-b.1.0",prv.ToString("SZ", null), "format combinations are allowed");

--- a/src/Ubiquity.NET.Versioning.UT/SkipTestMethodAttribute.cs
+++ b/src/Ubiquity.NET.Versioning.UT/SkipTestMethodAttribute.cs
@@ -1,4 +1,10 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿// -----------------------------------------------------------------------
+// <copyright file="SkipTestMethodAttribute.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Ubiquity.NET.Versioning.UT
 {

--- a/src/Ubiquity.NET.Versioning.slnx
+++ b/src/Ubiquity.NET.Versioning.slnx
@@ -8,12 +8,15 @@
     <File Path="../Directory.Build.props" />
     <File Path="../Directory.Build.targets" />
     <File Path="../Directory.Packages.props" />
+    <File Path="../GeneratedVersion.props" />
     <File Path="../global.json" />
+    <File Path="../Invoke-Tests.ps1" />
     <File Path="../Nuget.Config" />
     <File Path="../Push-Nuget.ps1" />
     <File Path="../README.md" />
     <File Path="../stylecop.json" />
     <File Path="../Ubiquity.NET.ruleset" />
+    <File Path=".runsettings" />
   </Folder>
   <Folder Name="/Solution Items/GitHub/" Id="831fc56c-5192-4533-bdd4-7bc366efe570" />
   <Folder Name="/Solution Items/GitHub/ISSUE_TEMPLATE/" Id="3b5f8dea-1188-472b-b762-43660c3b118b">
@@ -34,4 +37,5 @@
   <Project Path="Ubiquity.NET.Versioning.Build.Tasks/Ubiquity.NET.Versioning.Build.Tasks.csproj" />
   <Project Path="Ubiquity.NET.Versioning.UT/Ubiquity.NET.Versioning.UT.csproj" Id="a60f8801-7550-468e-9821-a120497a99ea" />
   <Project Path="Ubiquity.NET.Versioning/Ubiquity.NET.Versioning.csproj" />
+  <Project Path="Ubiquity.Versioning.Build.Tasks.UT/Ubiquity.Versioning.Build.Tasks.UT.csproj" Id="bbe39f21-9813-4093-acad-10b461dc3b1e" />
 </Solution>

--- a/src/Ubiquity.NET.Versioning/CSemVer.cs
+++ b/src/Ubiquity.NET.Versioning/CSemVer.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="CSemVer.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Globalization;
 using System.Linq;
 
@@ -12,7 +18,7 @@ namespace Ubiquity.NET.Versioning
         , IComparable<CSemVer>
         , IEquatable<CSemVer>
     {
-        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> struct</summary>
+        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> class</summary>
         /// <param name="major">Major version value [0-99999]</param>
         /// <param name="minor">Minor version value [0-49999]</param>
         /// <param name="patch">Patch version value [0-9999]</param>
@@ -99,10 +105,11 @@ namespace Ubiquity.NET.Versioning
         /// </remarks>
         public bool IsCIBuild { get; }
 
-        /// <summary>Gets a value indicating if this is a pre-release version</summary>
+        /// <summary>Gets a value indicating whether this is a pre-release version</summary>
         public bool IsPrerelease => PrereleaseVersion.IsValid;
 
         #region Comparison operators
+
         /// <inheritdoc/>
         public bool Equals( CSemVer? other ) => other is not null && CompareTo(other) == 0;
 
@@ -125,22 +132,40 @@ namespace Ubiquity.NET.Versioning
             return other is null ? 1 : FileVersion.CompareTo( other.FileVersion );
         }
 
-        /// <inheritdoc/>
+        /// <summary>Compares two <see cref="CSemVer"/> values (Less than)</summary>
+        /// <param name="left">Left hand side of the operation</param>
+        /// <param name="right">Right hand side of the operation</param>
+        /// <returns>Result of the comparison</returns>
         public static bool operator <( CSemVer left, CSemVer right ) => left.CompareTo( right ) < 0;
 
-        /// <inheritdoc/>
+        /// <summary>Compares two <see cref="CSemVer"/> values (Less than or equal)</summary>
+        /// <param name="left">Left hand side of the operation</param>
+        /// <param name="right">Right hand side of the operation</param>
+        /// <returns>Result of the comparison</returns>
         public static bool operator <=( CSemVer left, CSemVer right ) => left.CompareTo( right ) <= 0;
 
-        /// <inheritdoc/>
+        /// <summary>Compares two <see cref="CSemVer"/> values (Greater than)</summary>
+        /// <param name="left">Left hand side of the operation</param>
+        /// <param name="right">Right hand side of the operation</param>
+        /// <returns>Result of the comparison</returns>
         public static bool operator >( CSemVer left, CSemVer right ) => left.CompareTo( right ) > 0;
 
-        /// <inheritdoc/>
+        /// <summary>Compares two <see cref="CSemVer"/> values (Greater than or equal)</summary>
+        /// <param name="left">Left hand side of the operation</param>
+        /// <param name="right">Right hand side of the operation</param>
+        /// <returns>Result of the comparison</returns>
         public static bool operator >=( CSemVer left, CSemVer right ) => left.CompareTo( right ) >= 0;
 
-        /// <inheritdoc/>
-        public static bool operator ==( CSemVer? left, CSemVer? right ) => ReferenceEquals(left, right) || left is not null && left.Equals(right);
+        /// <summary>Compares two <see cref="CSemVer"/> values (Equals)</summary>
+        /// <param name="left">Left hand side of the operation</param>
+        /// <param name="right">Right hand side of the operation</param>
+        /// <returns>Result of the comparison</returns>
+        public static bool operator ==( CSemVer? left, CSemVer? right ) => ReferenceEquals(left, right) || (left is not null && left.Equals(right));
 
-        /// <inheritdoc/>
+        /// <summary>Compares two <see cref="CSemVer"/> values (Not Equal)</summary>
+        /// <param name="left">Left hand side of the operation</param>
+        /// <param name="right">Right hand side of the operation</param>
+        /// <returns>Result of the comparison</returns>
         public static bool operator !=( CSemVer? left, CSemVer? right ) => !(left == right);
         #endregion
 
@@ -162,8 +187,9 @@ namespace Ubiquity.NET.Versioning
         public string ToString( string? format, IFormatProvider? formatProvider )
         {
             format ??= "M";
+
             // Format provider is ignored; Representation is well defined externally and not dependent on culture
-            //formatProvider ??= CultureInfo.InvariantCulture;
+            // formatProvider ??= CultureInfo.InvariantCulture;
             if(format.Length > 2 || format.Any( c => c != 'M' && c != 'S' ))
             {
                 throw new ArgumentException( $"Invalid format '{format}'", nameof( format ) );
@@ -173,7 +199,6 @@ namespace Ubiquity.NET.Versioning
             bool useShortNames = format.Contains('S', StringComparison.Ordinal);
 
             var bldr = new System.Text.StringBuilder( );
-            bldr.Append( 'v' );
 
             bldr.AppendFormat( CultureInfo.InvariantCulture, "{0}.{1}.{2}", Major, Minor, Patch );
 
@@ -193,34 +218,6 @@ namespace Ubiquity.NET.Versioning
             }
 
             return bldr.ToString();
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> struct</summary>
-        /// <param name="major">Major version value [0-99999]</param>
-        /// <param name="minor">Minor version value [0-49999]</param>
-        /// <param name="patch">Patch version value [0-9999]</param>
-        /// <param name="isCIBuild">Indicates whether this is a CI build</param>
-        /// <param name="preRelVersion">Pre-release version information (if a pre-release build)</param>
-        /// <param name="buildMetaData">[Optional]Additional build meta data [default: empty string]</param>
-        /// <remarks>
-        /// This is used internally when converting from a File Version as those only have a single bit
-        /// to indicate they are a CI build. The rest of the information, which doesn't participate in sort
-        /// ordering, is lost.
-        /// </remarks>
-        private CSemVer( int major
-                       , int minor
-                       , int patch
-                       , bool isCIBuild
-                       , PrereleaseVersion preRelVersion = default
-                       , string buildMetaData = ""
-                       )
-        {
-            Major = major.ThrowIfOutOfRange(0, 99999 );
-            Minor = minor.ThrowIfOutOfRange(0, 49999 );
-            Patch = patch.ThrowIfOutOfRange(0, 9999 );
-            PrereleaseVersion = preRelVersion;
-            BuildMetaData = buildMetaData.ThrowIfNullOrWhitespaceOrLongerThan(20);
-            IsCIBuild = isCIBuild;
         }
 
         /// <summary>Converts a file version form (as a <see cref="UInt64"/>) of a CSemVer into a full <see cref="CSemVer"/></summary>
@@ -316,6 +313,34 @@ namespace Ubiquity.NET.Versioning
                               , ciBuildInfo
                               , buildMeta
                               );
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> class.</summary>
+        /// <param name="major">Major version value [0-99999]</param>
+        /// <param name="minor">Minor version value [0-49999]</param>
+        /// <param name="patch">Patch version value [0-9999]</param>
+        /// <param name="isCIBuild">Indicates whether this is a CI build</param>
+        /// <param name="preRelVersion">Pre-release version information (if a pre-release build)</param>
+        /// <param name="buildMetaData">[Optional]Additional build meta data [default: empty string]</param>
+        /// <remarks>
+        /// This is used internally when converting from a File Version as those only have a single bit
+        /// to indicate they are a CI build. The rest of the information, which doesn't participate in sort
+        /// ordering, is lost.
+        /// </remarks>
+        private CSemVer( int major
+                       , int minor
+                       , int patch
+                       , bool isCIBuild
+                       , PrereleaseVersion preRelVersion = default
+                       , string buildMetaData = ""
+                       )
+        {
+            Major = major.ThrowIfOutOfRange(0, 99999 );
+            Minor = minor.ThrowIfOutOfRange(0, 49999 );
+            Patch = patch.ThrowIfOutOfRange(0, 9999 );
+            PrereleaseVersion = preRelVersion;
+            BuildMetaData = buildMetaData.ThrowIfNullOrLongerThan(20);
+            IsCIBuild = isCIBuild;
         }
 
         private const ulong MulNum = 100;

--- a/src/Ubiquity.NET.Versioning/CiBuildInfo.cs
+++ b/src/Ubiquity.NET.Versioning/CiBuildInfo.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="CiBuildInfo.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Text.RegularExpressions;
 
 namespace Ubiquity.NET.Versioning
@@ -8,9 +14,9 @@ namespace Ubiquity.NET.Versioning
     public readonly partial record struct CiBuildInfo
         : IFormattable
     {
-        /// <summary></summary>
-        /// <param name="index"></param>
-        /// <param name="name"></param>
+        /// <summary>Initializes a new instance of the <see cref="CiBuildInfo"/> struct.</summary>
+        /// <param name="index">Build index for the build</param>
+        /// <param name="name">Build Name for the build</param>
         /// <remarks>
         /// The syntax for the <paramref name="index"/> and <paramref name="name"/> are restricted to only values that
         /// match the regular expression '\A[0-9a-zA-Z\-]+\Z' (ASCII alphanumeric plus a Hyphen).
@@ -70,10 +76,10 @@ namespace Ubiquity.NET.Versioning
             !string.IsNullOrWhiteSpace(BuildIndex)
           && !string.IsNullOrWhiteSpace(BuildName);
 
-        /// <summary>Build Index for this build</summary>
+        /// <summary>Gets the Build Index for this build</summary>
         public string BuildIndex { get; } = string.Empty;
 
-        /// <summary>Build name for this build</summary>
+        /// <summary>Gets the Build name for this build</summary>
         public string BuildName { get; } = string.Empty;
 
         private static readonly Regex CiBuildIdRegEx = new(@"\A[0-9a-zA-Z\-]+\Z");

--- a/src/Ubiquity.NET.Versioning/DateTimeOffsetExtensions.cs
+++ b/src/Ubiquity.NET.Versioning/DateTimeOffsetExtensions.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="DateTimeOffsetExtensions.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Globalization;
 
 namespace Ubiquity.NET.Versioning
@@ -23,8 +29,10 @@ namespace Ubiquity.NET.Versioning
         {
             // establish an increasing build index based on the number of seconds from a common UTC date
             timeStamp = timeStamp.ToUniversalTime( );
+
             // Upper 16 bits of the build number is the number of days since the common base value
             uint buildNumber = ((uint)(timeStamp - CommonBaseDate).Days) << 16;
+
             // Lower 16 bits is the number of seconds (divided by 2) since midnight (on the date of the time stamp)
             var midnightTodayUtc = new DateTime( timeStamp.Year, timeStamp.Month, timeStamp.Day, 0, 0, 0, DateTimeKind.Utc );
             buildNumber += (ushort)((timeStamp - midnightTodayUtc).TotalSeconds / 2);

--- a/src/Ubiquity.NET.Versioning/FileVersionQuad.cs
+++ b/src/Ubiquity.NET.Versioning/FileVersionQuad.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="FileVersionQuad.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 
 namespace Ubiquity.NET.Versioning
 {
@@ -13,12 +19,13 @@ namespace Ubiquity.NET.Versioning
     /// and has grown as it is simple, and naturally fits (maps to) an unsigned 64bit value. Thus,
     /// CSemVer defines a specific mapping of values to this common format.</para>
     /// <para>A standard .NET <see cref="Version"/> is very similar except that the bit width of each
-    /// field is larger AND they are signed values.
+    /// field is larger AND they are signed values. That is, every <see cref="FileVersionQuad"/> can
+    /// produce a valid .NET <see cref="Version"/>. However, not every <see cref="Version"/> can result
+    /// in a valid <see cref="FileVersionQuad"/>.
     /// </para>
     /// </remarks>
     public readonly record struct FileVersionQuad( UInt16 Major, UInt16 Minor, UInt16 Build, UInt16 Revision )
         : IComparable<FileVersionQuad>
-        //, IComparisonOperators<FileVersionQuad, FileVersionQuad, bool>
     {
         /// <summary>Gets the UInt64 representation of the version</summary>
         /// <returns>UInt64 version of the version</returns>
@@ -42,16 +49,28 @@ namespace Ubiquity.NET.Versioning
             return ToUInt64().CompareTo(other.ToUInt64());
         }
 
-        /// <inheritdoc/>
+        /// <summary>Compares versions (Less than)</summary>
+        /// <param name="left">Left hand side of the comparison</param>
+        /// <param name="right">Right hand side of the comparison</param>
+        /// <returns>Result of the comparison</returns>
         public static bool operator <( FileVersionQuad left, FileVersionQuad right ) => left.CompareTo( right ) < 0;
 
-        /// <inheritdoc/>
+        /// <summary>Compares versions (Less than or Equal)</summary>
+        /// <param name="left">Left hand side of the comparison</param>
+        /// <param name="right">Right hand side of the comparison</param>
+        /// <returns>Result of the comparison</returns>
         public static bool operator <=( FileVersionQuad left, FileVersionQuad right ) => left.CompareTo( right ) <= 0;
 
-        /// <inheritdoc/>
+        /// <summary>Compares versions (Greater than)</summary>
+        /// <param name="left">Left hand side of the comparison</param>
+        /// <param name="right">Right hand side of the comparison</param>
+        /// <returns>Result of the comparison</returns>
         public static bool operator >( FileVersionQuad left, FileVersionQuad right ) => left.CompareTo( right ) > 0;
 
-        /// <inheritdoc/>
+        /// <summary>Compares versions (Greater than or equal)</summary>
+        /// <param name="left">Left hand side of the comparison</param>
+        /// <param name="right">Right hand side of the comparison</param>
+        /// <returns>Result of the comparison</returns>
         public static bool operator >=( FileVersionQuad left, FileVersionQuad right ) => left.CompareTo( right ) >= 0;
 
         /// <summary>Converts this instance to a <see cref="Version"/></summary>
@@ -59,6 +78,20 @@ namespace Ubiquity.NET.Versioning
         public Version ToVersion( )
         {
             return new Version( Major, Minor, Build, Revision );
+        }
+
+        /// <summary>Converts a <see cref="Version"/> value to a <see cref="FileVersionQuad"/> if possible</summary>
+        /// <param name="v">Version to convert</param>
+        /// <returns>Resulting <see cref="FileVersionQuad"/></returns>
+        /// <exception cref="ArgumentOutOfRangeException">At least one of the members of <paramref name="v"/> is out of range of a <see cref="UInt16"/></exception>
+        public static FileVersionQuad From( Version v)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(v.Major, UInt16.MaxValue);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(v.Minor, UInt16.MaxValue);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(v.Build, UInt16.MaxValue);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(v.Revision, UInt16.MaxValue);
+
+            return new((UInt16)v.Major, (UInt16)v.Minor, (UInt16)v.Build, (UInt16)v.Revision);
         }
 
         /// <summary>Converts a version integral value into a <see cref="FileVersionQuad"/></summary>

--- a/src/Ubiquity.NET.Versioning/ParsedBuildVersionXml.cs
+++ b/src/Ubiquity.NET.Versioning/ParsedBuildVersionXml.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="ParsedBuildVersionXml.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Globalization;
 using System.IO;
 using System.Xml.Linq;

--- a/src/Ubiquity.NET.Versioning/PrereleaseVersion.cs
+++ b/src/Ubiquity.NET.Versioning/PrereleaseVersion.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="PrereleaseVersion.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -43,7 +49,7 @@ namespace Ubiquity.NET.Versioning
             preRelFix.ThrowIfOutOfRange(0, 99);
 
             var q = from name in PreReleaseNames.Select( ( n, i ) => new { Name = n, Index = i } )
-                    where 0 == string.Compare( name.Name, preRelName, StringComparison.OrdinalIgnoreCase )
+                    where string.Equals( name.Name, preRelName, StringComparison.OrdinalIgnoreCase )
                     select name;
 
             var nameIndex = q.FirstOrDefault( ) ?? throw new ArgumentException("Invalid pre-release name", nameof(preRelName));
@@ -89,6 +95,7 @@ namespace Ubiquity.NET.Versioning
         /// <remarks>
         /// This assumes the Full (F) format of the pre-release information
         /// </remarks>
+        /// <returns>The formatted version information</returns>
         public override string ToString( ) => ToString( "F", CultureInfo.InvariantCulture );
 
         /// <summary>Formats this instance as a string according to the rules of a Constrained Semantic Version</summary>
@@ -134,7 +141,7 @@ namespace Ubiquity.NET.Versioning
             }
 
             // Format provider is ignored; string form is well defined externally based on invariant culture
-            //formatProvider ??= CultureInfo.InvariantCulture;
+            // formatProvider ??= CultureInfo.InvariantCulture;
             var bldr = new StringBuilder( );
 
             bldr.Append( '-' )

--- a/src/Ubiquity.NET.Versioning/Ubiquity.NET.Versioning.csproj
+++ b/src/Ubiquity.NET.Versioning/Ubiquity.NET.Versioning.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <!-- Consumed by MSBuild Task in VS which only builds on .NET Framework -->
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <PackageId>Ubiquity.NET.Versioning</PackageId>
         <Authors>UbiquityDotNET</Authors>
@@ -20,26 +19,31 @@
         <LangVersion>13</LangVersion>
     </PropertyGroup>
     <!--
-    For local builds of this project in IDE, FORCE the BuildInfo as there is no lib to rely on; (This repo builds it!)
-    Automated builds/Command line builds use the PowerShell scripts to setup the variables for use in the build. This,
-    handles the case of builds directly from the IDE so that can complete a compilation. [Though, it should ONLY be
-    used for local testing. Running the scripts locally from a command line is the final best test of a given set of
-    changes to the source]
+    For local builds of this project in IDE ONLY
+    FORCE the Build Versioning Info as there is no lib to rely on; (This repo builds it!) and the automated build
+    scripts aren't used to build from within an IDE. Automated builds/Command line builds use the PowerShell
+    scripts to setup the variables for use in the build. This, handles the case of builds directly from the IDE
+    so that can complete a compilation.
+
+    Though, it should ONLY be used for local testing. Running the scripts locally from a command line is
+    the final best test of a given set of changes to the source.
     -->
     <PropertyGroup Condition="'$(IsAutomatedBuild)' != 'true' AND '$(CiBuildIndex)'==''">
         <CiBuildIndex>$([System.UInt32]::MaxValue)</CiBuildIndex>
         <CiBuildName>IDE</CiBuildName>
-        <BuildMajor>4</BuildMajor>
+        <BuildMajor>5</BuildMajor>
         <BuildMinor>0</BuildMinor>
         <BuildPatch>0</BuildPatch>
         <PreReleaseName>alpha</PreReleaseName>
         <PreReleaseNumber>0</PreReleaseNumber>
         <PreReleaseFix>0</PreReleaseFix>
-        <!-- File Version for v4.0.0.alpha (See: https://csemver.org/playground/site/#/) -->
+        <!-- File Version for v5.0.0-alpha (See: https://csemver.org/playground/site/#/) [1.27597.27630.61954]-->
         <FileVersionMajor>1</FileVersionMajor>
-        <FileVersionMinor>8970</FileVersionMinor>
-        <FileVersionBuild>48319</FileVersionBuild>
-        <FileVersionRevision>10242</FileVersionRevision>
+        <FileVersionMinor>27597</FileVersionMinor>
+        <FileVersionBuild>27630</FileVersionBuild>
+        <FileVersionRevision>61954</FileVersionRevision>
+
+        <!-- Force a local CI build for all IDE builds -->
         <FullBuildNumber>$(BuildMajor).$(BuildMinor).$(BuildPatch)-$(PreReleaseName).ci-ZZZ.$(CiBuildIndex)</FullBuildNumber>
         <PackageVersion>$(BuildMajor).$(BuildMinor).$(BuildPatch)-a.ci-ZZZ.$(CiBuildIndex)</PackageVersion>
     </PropertyGroup>

--- a/src/Ubiquity.NET.Versioning/ValidateArg.cs
+++ b/src/Ubiquity.NET.Versioning/ValidateArg.cs
@@ -1,11 +1,16 @@
-﻿using System;
+﻿// -----------------------------------------------------------------------
+// <copyright file="ValidateArg.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 namespace Ubiquity.NET.Versioning
 {
-
     // TODO: With C#14 extensions it should be possible to make these a static method extension to the exception types
     //       so that it appears as a static method to that class. Allowing syntax like:
     //       ArgumentException.ThrowIfNotMatch(inputStr, myRegEx);
@@ -25,7 +30,7 @@ namespace Ubiquity.NET.Versioning
             self.ThrowIfNull(exp);
             if(self.CompareTo( min ) < 0 || self.CompareTo( max ) > 0)
             {
-                throw new ArgumentOutOfRangeException( exp );
+                throw new ArgumentOutOfRangeException( exp, self, $"Value is outside of range [{min}-{max}]");
             }
 
             return self;
@@ -33,18 +38,24 @@ namespace Ubiquity.NET.Versioning
 
         public static T ThrowIfNull<T>([NotNull] this T? self, [CallerArgumentExpression( nameof( self ) )] string? exp = null)
         {
-            return self is not null ? self : throw new ArgumentException(exp);
+            return self is not null ? self : throw new ArgumentNullException(exp);
         }
 
         public static string ThrowIfNullOrWhiteSpace( [NotNull] this string? self, [CallerArgumentExpression( nameof( self ) )] string? exp = null )
         {
-            self.ThrowIfNull();
-            return !string.IsNullOrWhiteSpace(self) ? self : throw new ArgumentException(exp);
+            self.ThrowIfNull(exp);
+            return !string.IsNullOrWhiteSpace(self) ? self : throw new ArgumentException("Argument is Null or White Space", exp);
         }
 
         public static string ThrowIfNullOrWhitespaceOrLongerThan([NotNull] this string? self, int length, [CallerArgumentExpression( nameof( self ) )] string? exp = null)
         {
             self.ThrowIfNullOrWhiteSpace(exp);
+            return self.Length <= length ? self : throw new ArgumentException($"Length of {self.Length} exceeds limit {length}", exp);
+        }
+
+        public static string ThrowIfNullOrLongerThan([NotNull] this string? self, int length, [CallerArgumentExpression( nameof( self ) )] string? exp = null)
+        {
+            self.ThrowIfNull(exp);
             return self.Length <= length ? self : throw new ArgumentException($"Length of {self.Length} exceeds limit {length}", exp);
         }
     }

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/AssemblyInfo.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/AssemblyInfo.cs
@@ -1,0 +1,23 @@
+// -----------------------------------------------------------------------
+// <copyright file="AssemblyInfo.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Runtime.InteropServices;
+
+// In SDK-style projects such as this one, several assembly attributes that were historically
+// defined in this file are now automatically added during build and populated with
+// values defined in project properties. For details of which attributes are included
+// and how to customize this process see: https://aka.ms/assembly-info-properties
+
+// Setting ComVisible to false makes the types in this assembly not visible to COM
+// components.  If you need to access a type in this assembly from COM, set the ComVisible
+// attribute to true on that type.
+[assembly: ComVisible( false )]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM.
+[assembly: Guid( "c2962f0e-5a4d-4dc0-ba02-89562beab4e5" )]
+
+[assembly: CLSCompliant( false )]

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/BuildProperties.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/BuildProperties.cs
@@ -1,0 +1,103 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BuildProperties.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+
+using Microsoft.Build.Execution;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    /// <summary>Captures all properties for the build task</summary>
+    /// <remarks>
+    /// It is worth noting that the properties captured are ALL considered
+    /// "OPTIONAL" here. It is up to tests to VERIFY if a property is supposed
+    /// to be present or not.
+    /// </remarks>
+    internal readonly record struct BuildProperties
+    {
+        public BuildProperties( BuildResult result )
+        {
+            ArgumentNullException.ThrowIfNull(result.ProjectStateAfterBuild);
+            var inst = result.ProjectStateAfterBuild;
+
+            // Manually or from Ubiquity.NET.Versioning.Build.Tasks.props
+            BuildTime = inst.GetPropertyValue("BuildTime");
+            CiBuildName = inst.GetPropertyValue("CiBuildName");
+
+            // from Ubiquity.NET.Versioning.Build.Tasks.targets/GetRepositoryInfo/GetBuildIndexFromTime task
+            CiBuildIndex = inst.GetPropertyValue("CiBuildIndex");
+
+            // Either manually or from Ubiquity.NET.Versioning.Build.Tasks.targets/GetRepositoryInfo/ParseBuildVersionXml task
+            BuildMajor = inst.GetPropertyAs<UInt16>("BuildMajor");
+            BuildMinor = inst.GetPropertyAs<UInt16>("BuildMinor");
+            BuildPatch = inst.GetPropertyAs<UInt16>("BuildPatch");
+            PreReleaseName = inst.GetOptionalProperty("PreReleaseName");
+            PreReleaseNumber = inst.GetPropertyAs<UInt16>("PreReleaseNumber");
+            PreReleaseFix = inst.GetPropertyAs<UInt16>("PreReleaseFix");
+
+            // from Ubiquity.NET.Versioning.Build.Tasks.targets/GetRepositoryInfo/CreateVersionInfo task
+            FullBuildNumber = inst.GetOptionalProperty("FullBuildNumber");
+            FileVersionMajor = inst.GetPropertyAs<UInt16>("FileVersionMajor");
+            FileVersionMinor =inst.GetPropertyAs<UInt16>("FileVersionMinor");
+            FileVersionBuild = inst.GetPropertyAs<UInt16>("FileVersionBuild");
+            FileVersionRevision = inst.GetPropertyAs<UInt16>("FileVersionRevision");
+            PackageVersion = inst.GetOptionalProperty("PackageVersion");
+
+            // from Ubiquity.NET.Versioning.Build.Tasks.targets/SetVersionDependentProperties target
+            FileVersion = inst.GetOptionalProperty("FileVersion");
+            AssemblyVersion = inst.GetOptionalProperty("AssemblyVersion");
+            InformationalVersion = inst.GetOptionalProperty("InformationalVersion");
+
+            IsPullRequestBuild = inst.GetPropertyAs<bool>("IsPullRequestBuild");
+            IsAutomatedBuild = inst.GetPropertyAs<bool>("IsAutomatedBuild");
+            IsReleaseBuild = inst.GetPropertyAs<bool>("IsReleaseBuild");
+        }
+
+        public UInt16? BuildMajor { get; }
+
+        public UInt16? BuildMinor { get; }
+
+        public UInt16? BuildPatch { get; }
+
+        public string? PreReleaseName { get; }
+
+        public UInt16? PreReleaseNumber { get; }
+
+        public UInt16? PreReleaseFix { get; }
+
+        public string? FullBuildNumber { get; }
+
+        public string? PackageVersion { get; }
+
+        public string? BuildTime { get; }
+
+        public string? CiBuildIndex { get; }
+
+        public string? CiBuildName { get; }
+
+        public UInt16? FileVersionMajor { get; }
+
+        public UInt16? FileVersionMinor { get; }
+
+        public UInt16? FileVersionBuild { get; }
+
+        public UInt16? FileVersionRevision { get; }
+
+        public string? BuildMeta { get; }
+
+        public string? FileVersion { get; }
+
+        public string? AssemblyVersion { get; }
+
+        public string? InformationalVersion { get; }
+
+        public bool? IsPullRequestBuild { get; }
+
+        public bool? IsAutomatedBuild { get; }
+
+        public bool? IsReleaseBuild { get; }
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/BuildTaskTests.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/BuildTaskTests.cs
@@ -1,0 +1,290 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BuildTaskTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+using System.Xml.Linq;
+
+using Microsoft.Build.Utilities.ProjectCreation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    [TestClass]
+    public class BuildTaskTests
+        : MSBuildTestBase
+    {
+        public BuildTaskTests( TestContext ctx )
+        {
+            Context = ctx;
+            ArgumentException.ThrowIfNullOrWhiteSpace( ctx.TestResultsDirectory );
+        }
+
+        public TestContext Context { get; }
+
+        [TestMethod]
+        public void ValidateRepoAssemblyVersion( )
+        {
+            // Repo assembly versions are defined via PowerShell (Or hard coded in the project file
+            // for IDE builds) as the build task is not usable for itself. This verifies the build
+            // versioning matches what is expected for an end-consumer by testing the assemblies
+            // versioning information against the output from THAT task assembly. This should be identical
+            // for IDE builds AND command line builds. Basically this verifies the manual IDE properties
+            // AND/OR the automated build scripting matches what the task itself expects. If anything is
+            // out of whack, this will complain.
+            var (testProject, props) = CreateTestProjectAndInvokeTestedPackage(
+                pc => pc.Property( "BuildVersionXml", Path.Combine(RepoRoot, "BuildVersion.xml"))
+            );
+            string? taskAssembly = testProject.ProjectInstance.GetOptionalProperty("_Ubiquity_NET_Versioning_Build_Tasks");
+            Assert.IsNotNull( taskAssembly, "Task assembly property should contain full path to the task DLL (Not NULL)" );
+            Context.WriteLine( $"Task Assembly: '{taskAssembly}'" );
+            Assert.IsFalse( string.IsNullOrWhiteSpace( taskAssembly ), "Task assembly property should contain full path to the task DLL (Not Whitespace)" );
+            Assert.IsNotNull( props.FileVersion, "Generated properties should have a 'FileVersion'" );
+            Context.WriteLine( $"Generated FileVersion: {props.FileVersion}" );
+            var alc = new AssemblyLoadContext("TestALC", isCollectible: true);
+            try
+            {
+                var asm = alc.LoadFromAssemblyPath(taskAssembly);
+                Assert.IsNotNull( asm, "should be able to load task assembly" );
+                var asmName = asm.GetName();
+                Version? asmVer = asmName.Version;
+                Assert.IsNotNull( asmVer, "Task assembly should have a version" );
+                Context.WriteLine( $"TaskAssemblyVersion: {asmVer}" );
+                Context.WriteLine( $"AssemblyName: {asmName}" );
+                Assert.IsNotNull( props.FileVersionMajor, "Property value for Major should exist" );
+                Assert.AreEqual( (int)props.FileVersionMajor, asmVer.Major, "Major value of assembly version should match" );
+
+                Assert.IsNotNull( props.FileVersionMinor, "Property value for Minor should exist" );
+                Assert.AreEqual( (int)props.FileVersionMinor, asmVer.Minor, "Minor value of assembly version should match" );
+
+                Assert.IsNotNull( props.FileVersionBuild, "Property value for Build should exist" );
+                Assert.AreEqual( (int)props.FileVersionBuild, asmVer.Build, "Build value of assembly version should match" );
+
+                Assert.IsNotNull( props.FileVersionRevision, "Property value for Revision should exist" );
+                Assert.AreEqual( (int)props.FileVersionRevision, asmVer.Revision, "Revision value of assembly version should match" );
+            }
+            finally
+            {
+                alc.Unload();
+            }
+        }
+
+        [TestMethod]
+        public void GoldenPathTest( )
+        {
+            var (testProject, props) = CreateTestProjectAndInvokeTestedPackage(
+                pc => pc.PropertyGroup()
+                        .Property("BuildMajor", "20")
+                        .Property("BuildMinor", "1")
+                        .Property("BuildPatch", "4")
+                        .Property("PreReleaseName", "alpha")
+            );
+
+            // v20.1.4-alpha => 5.44854.3875.59946 [see: https://csemver.org/playground/site/#/]
+            // NOTE: CI build is +1 (FileVersionRevision)!
+            string expectedFullBuildNumber = $"20.1.4-alpha.ci.{props.CiBuildIndex}.{props.CiBuildName}";
+            string expectedShortNumber = $"20.1.4-a.0.0.ci.{props.CiBuildIndex}.{props.CiBuildName}";
+            string expectedFileVersion = "5.44854.3875.59947";
+
+            Assert.IsNotNull( props.BuildMajor, "should have a value set for 'BuildMajor'" );
+            Assert.AreEqual( 20u, props.BuildMajor.Value );
+
+            Assert.IsNotNull( props.BuildMinor, "should have a value set for 'BuildMinor'" );
+            Assert.AreEqual( 1u, props.BuildMinor.Value );
+
+            Assert.IsNotNull( props.BuildPatch, "should have a value set for 'BuildPatch'" );
+            Assert.AreEqual( 4, props.BuildPatch.Value );
+
+            Assert.IsNotNull( props.PreReleaseName, "should have a value set for 'PreReleaseName'" );
+            Assert.AreEqual( "alpha", props.PreReleaseName );
+
+            Assert.IsNull( props.PreReleaseNumber, "Should NOT have a value set for 'PreReleaseNumber'" );
+            Assert.IsNull( props.PreReleaseFix, "Should NOT have a value set for 'PreReleaseNumber'" );
+
+            // NOTE: Since build index is based on time which is captured during build it
+            // is not possible to know 'a priori' what the value will be... Other, tests
+            // validate the behavior of that with an explicit setting...
+            Assert.AreEqual( expectedFullBuildNumber, props.FullBuildNumber );
+            Assert.AreEqual( expectedShortNumber, props.PackageVersion );
+
+            // TODO: Test that time is in ISO-8601 format and within a few seconds of "now"
+            // For now, just make sure they aren't null or empty
+            Assert.IsFalse( string.IsNullOrWhiteSpace( props.BuildTime ) );
+            Assert.IsFalse( string.IsNullOrWhiteSpace( props.CiBuildIndex ) );
+
+            Assert.AreEqual( "ZZZ", props.CiBuildName );
+
+            Assert.IsNotNull( props.FileVersionMajor );
+            Assert.AreEqual( 5, props.FileVersionMajor.Value );
+
+            Assert.IsNotNull( props.FileVersionMinor );
+            Assert.AreEqual( 44854, props.FileVersionMinor.Value );
+
+            Assert.IsNotNull( props.FileVersionBuild );
+            Assert.AreEqual( 3875, props.FileVersionBuild.Value );
+
+            Assert.IsNotNull( props.FileVersionRevision );
+            Assert.AreEqual( 59947, props.FileVersionRevision.Value );
+
+            Assert.AreEqual( expectedFileVersion, props.FileVersion );
+            Assert.AreEqual( expectedFileVersion, props.AssemblyVersion );
+            Assert.AreEqual( expectedFullBuildNumber, props.InformationalVersion );
+        }
+
+        [TestMethod]
+        public void BuildVersionXmlIsUsed( )
+        {
+            string buildVersionXml = CreateTempBuildVersionXml(20, 1, 5);
+            string buildTime = DateTime.UtcNow.ToString( "o" );
+            const string buildIndex = "ABCDEF12";
+
+            var (testProject, props) = CreateTestProjectAndInvokeTestedPackage(
+                pc =>
+                    pc.PropertyGroup()
+                      .Property( "BuildTime", buildTime )
+                      .Property( "CiBuildIndex", buildIndex )
+                      .Property( "BuildVersionXml", buildVersionXml )
+            );
+
+            // v20.1.5 => 5.44854.3880.52268 [see: https://csemver.org/playground/site/#/]
+            // NOTE: CI build is +1 (FileVersionRevision)!
+            string expectedFullBuildNumber = $"20.1.5--ci.ABCDEF12.ZZZ";
+            string expectedShortNumber = $"20.1.5--ci.ABCDEF12.ZZZ";
+            string expectedFileVersion = "5.44854.3880.52269";
+
+            Assert.IsNotNull( props.BuildMajor );
+            Assert.AreEqual( 20u, props.BuildMajor.Value );
+
+            Assert.IsNotNull( props.BuildMinor );
+            Assert.AreEqual( 1u, props.BuildMinor.Value );
+
+            Assert.IsNotNull( props.BuildPatch );
+            Assert.AreEqual( 5u, props.BuildPatch.Value );
+
+            Assert.IsNull( props.PreReleaseName );
+
+            Assert.IsNotNull( props.PreReleaseNumber );
+            Assert.AreEqual( 0, props.PreReleaseNumber.Value );
+
+            Assert.IsNotNull( props.PreReleaseFix );
+            Assert.AreEqual( 0, props.PreReleaseFix.Value );
+
+            Assert.AreEqual( expectedFullBuildNumber, props.FullBuildNumber );
+            Assert.AreEqual( expectedShortNumber, props.PackageVersion );
+
+            // Test for expected global properties (Should not change values)
+            Assert.AreEqual( buildTime, props.BuildTime );
+            Assert.AreEqual( buildIndex, props.CiBuildIndex );
+
+            Assert.AreEqual( "ZZZ", props.CiBuildName );
+
+            Assert.IsNotNull( props.FileVersionMajor );
+            Assert.AreEqual( 5, props.FileVersionMajor.Value );
+
+            Assert.IsNotNull( props.FileVersionMinor );
+            Assert.AreEqual( 44854, props.FileVersionMinor.Value );
+
+            Assert.IsNotNull( props.FileVersionBuild );
+            Assert.AreEqual( 3880, props.FileVersionBuild.Value );
+
+            Assert.IsNotNull( props.FileVersionRevision );
+            Assert.AreEqual( 52269, props.FileVersionRevision.Value );
+
+            Assert.AreEqual( expectedFileVersion, props.FileVersion );
+            Assert.AreEqual( expectedFileVersion, props.AssemblyVersion );
+            Assert.AreEqual( expectedFullBuildNumber, props.InformationalVersion );
+        }
+
+        internal string RepoRoot => Context.TestRunDirectory is null
+                                    ? string.Empty
+                                    : Path.GetFullPath( Path.Combine( Context.TestRunDirectory, "..", "..", ".." ) );
+
+        private (ProjectCreator Project, BuildProperties ResultProps) CreateTestProjectAndInvokeTestedPackage(
+            Action<ProjectCreator>? action = null,
+            [CallerMemberName] string? testName = null
+            )
+        {
+            var (testProject, resolveResult) = CreateAndResolveTestProject( action, testName );
+            Assert.IsTrue( resolveResult );
+
+            // Since this project uses an imported target, it won't even exist until AFTER ResolvePackageDependencies[DesignTime|ForBuild] comes along.
+            var result = testProject.ProjectInstance.Build("PrepareVersioningForBuild");
+            Assert.IsNotNull( result );
+            Assert.IsNotNull( result.ProjectStateAfterBuild );
+
+            return (testProject, new BuildProperties( result ));
+        }
+
+        private (ProjectCreator Project, bool ResolveResult) CreateAndResolveTestProject( Action<ProjectCreator>? action = null, [CallerMemberName] string? testName = null )
+        {
+            var project = ProjectCreator.Templates
+                                        .VersioningProject( customAction: action )
+                                        .Save( Path.Combine( Context.TestResultsDirectory!, $"{nameof( BuildTaskTests )}-{testName}.csproj" ) )
+                                        .TryBuild(
+                                            restore: true,
+                                            "ResolvePackageDependenciesDesignTime",
+                                            out bool resolveResult,
+                                            out BuildOutput resolveBuildOutput
+                                            );
+
+            using(resolveBuildOutput)
+            {
+                ShowBuildErrors( resolveBuildOutput );
+            }
+
+            return (project, resolveResult);
+        }
+
+        private void ShowBuildErrors( BuildOutput buildOutput )
+        {
+            foreach(var err in buildOutput.ErrorEvents)
+            {
+                // output build errors in standard MSBuild format
+                // see: https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks?view=vs-2022
+                Context.WriteLine( $"{err.ProjectFile}({err.LineNumber},{err.ColumnNumber}) : {err.Subcategory} error {err.Code} : {err.Message}" );
+            }
+        }
+
+        private string CreateTempBuildVersionXml(
+            int buildMajor,
+            int buildMinor,
+            int buildPatch,
+            string? preReleaseName = null,
+            int? preReleaseNumber = null,
+            int? preReleaseFix = null
+            )
+        {
+            Assert.IsNotNull( Context.DeploymentDirectory );
+            string retVal = Path.Combine(Context.DeploymentDirectory, Path.GetRandomFileName());
+            using var strm = File.Open(retVal, FileMode.CreateNew);
+            var element = new XElement("BuildVersionData",
+                                        new XAttribute("BuildMajor", buildMajor),
+                                        new XAttribute("BuildMinor", buildMinor),
+                                        new XAttribute("BuildPatch", buildPatch)
+                                        );
+            if(!string.IsNullOrWhiteSpace( preReleaseName ))
+            {
+                element.Add( new XAttribute( "PreReleaseName", preReleaseName ) );
+            }
+
+            if(preReleaseNumber.HasValue)
+            {
+                element.Add( new XAttribute( "PreReleaseNumber", preReleaseNumber.Value ) );
+            }
+
+            if(preReleaseFix.HasValue)
+            {
+                element.Add( new XAttribute( "PreReleaseNumber", preReleaseFix.Value ) );
+            }
+
+            element.Save( strm );
+            Context.WriteLine( $"BuildVersionXML written to: '{retVal}'" );
+            return retVal;
+        }
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/GlobalSuppressions.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/GlobalSuppressions.cs
@@ -1,0 +1,14 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="GlobalSuppressions.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Unit Tests" )]
+[assembly: SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1652:Enable XML documentation output", Justification = "Unit Tests" )]

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ModuleInitializer.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ModuleInitializer.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 
 using Microsoft.Build.Utilities.ProjectCreation;
 
+// .NET Module initializer to register MSBUILD resolver as per docs for library.
 internal static class ModuleInitializer
 {
     [ModuleInitializer]

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ModuleInitializer.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ModuleInitializer.cs
@@ -1,0 +1,18 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ModuleInitializer.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+using Microsoft.Build.Utilities.ProjectCreation;
+
+internal static class ModuleInitializer
+{
+    [ModuleInitializer]
+    internal static void InitializeMSBuild()
+    {
+        MSBuildAssemblyResolver.Register();
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectCreatorLibraryExtensions.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectCreatorLibraryExtensions.cs
@@ -7,56 +7,21 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Linq;
 
 using Microsoft.Build.Evaluation;
-using Microsoft.Build.Execution;
-using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities.ProjectCreation;
 
 namespace Ubiquity.Versioning.Build.Tasks.UT
 {
     internal static class ProjectCreatorLibraryExtensions
     {
-        public static T? GetPropertyAs<T>(this ProjectInstance self, string name, T? defaultValue = null)
-            where T : struct
-        {
-            var prop = self.GetProperty(name);
-            return prop is null ? defaultValue : (T?)Convert.ChangeType(prop.EvaluatedValue, typeof(T), CultureInfo.InvariantCulture);
-        }
-
-        public static string? GetOptionalProperty(this ProjectInstance self, string name, string? defaultValue = null)
-        {
-            var prop = self.GetProperty(name);
-            return prop is null ? defaultValue : prop.EvaluatedValue;
-        }
-
-        // Sadly, project creator library doesn't have support for after build state retrieval...
-        // Fortunately, it is fairly easy to create an extension to handle that scenario.
-        public static BuildResult Build(this ProjectInstance self, params string[] targetsToBuild)
-        {
-            return BuildManager.DefaultBuildManager.Build(
-                                    new BuildParameters(),
-                                    new BuildRequestData(
-                                        self,
-                                        targetsToBuild,
-                                        new HostServices(),
-                                        BuildRequestDataFlags.ProvideProjectStateAfterBuild
-                                        )
-                                    );
-        }
-
         [SuppressMessage( "Style", "IDE0060:Remove unused parameter", Justification = "Syntactical sugar" )]
+        [SuppressMessage( "Style", "IDE0046:Convert to conditional expression", Justification = "Result is Less than 'simplified'" )]
         public static ProjectCreator VersioningProject(
             this ProjectCreatorTemplates templates,
+            string targetFramework,
             Action<ProjectCreator>? customAction = null,
             string? path = null,
-#if NETFRAMEWORK
-            string targetFramework = "net472",
-#else
-            string targetFramework = "netstandard2.0",
-#endif
             string? defaultTargets = null,
             string? initialTargets = null,
             string sdk = "Microsoft.NET.Sdk",
@@ -66,6 +31,8 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
             IDictionary<string, string>? globalProperties = null,
             NewProjectFileOptions? projectFileOptions = NewProjectFileOptions.None)
         {
+            ArgumentException.ThrowIfNullOrWhiteSpace(targetFramework);
+
             return templates.SdkCsproj(
                                 path,
                                 sdk,

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectCreatorLibraryExtensions.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectCreatorLibraryExtensions.cs
@@ -1,0 +1,90 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ProjectCreatorLibraryExtensions.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities.ProjectCreation;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    internal static class ProjectCreatorLibraryExtensions
+    {
+        public static T? GetPropertyAs<T>(this ProjectInstance self, string name, T? defaultValue = null)
+            where T : struct
+        {
+            var prop = self.GetProperty(name);
+            return prop is null ? defaultValue : (T?)Convert.ChangeType(prop.EvaluatedValue, typeof(T), CultureInfo.InvariantCulture);
+        }
+
+        public static string? GetOptionalProperty(this ProjectInstance self, string name, string? defaultValue = null)
+        {
+            var prop = self.GetProperty(name);
+            return prop is null ? defaultValue : prop.EvaluatedValue;
+        }
+
+        // Sadly, project creator library doesn't have support for after build state retrieval...
+        // Fortunately, it is fairly easy to create an extension to handle that scenario.
+        public static BuildResult Build(this ProjectInstance self, params string[] targetsToBuild)
+        {
+            return BuildManager.DefaultBuildManager.Build(
+                                    new BuildParameters(),
+                                    new BuildRequestData(
+                                        self,
+                                        targetsToBuild,
+                                        new HostServices(),
+                                        BuildRequestDataFlags.ProvideProjectStateAfterBuild
+                                        )
+                                    );
+        }
+
+        [SuppressMessage( "Style", "IDE0060:Remove unused parameter", Justification = "Syntactical sugar" )]
+        public static ProjectCreator VersioningProject(
+            this ProjectCreatorTemplates templates,
+            Action<ProjectCreator>? customAction = null,
+            string? path = null,
+#if NETFRAMEWORK
+            string targetFramework = "net472",
+#else
+            string targetFramework = "netstandard2.0",
+#endif
+            string? defaultTargets = null,
+            string? initialTargets = null,
+            string sdk = "Microsoft.NET.Sdk",
+            string? toolsVersion = null,
+            string? treatAsLocalProperty = null,
+            ProjectCollection? projectCollection = null,
+            IDictionary<string, string>? globalProperties = null,
+            NewProjectFileOptions? projectFileOptions = NewProjectFileOptions.None)
+        {
+            return templates.SdkCsproj(
+                                path,
+                                sdk,
+                                targetFramework,
+                                outputType: null,
+                                customAction,
+                                defaultTargets,
+                                initialTargets,
+                                treatAsLocalProperty,
+                                projectCollection,
+                                projectFileOptions,
+                                globalProperties
+                                ).ItemPackageReference(PackageUnderTestId, version: "5.0.0-*", privateAssets: "All")
+                                 .Property("Nullable", "disable")
+                                 .Property("ManagePackageVersionsCentrally", "false")
+                                 .Property("ImplicitUsings","disable")
+                                 ;
+        }
+
+        private const string PackageUnderTestId = @"Ubiquity.NET.Versioning.Build.Tasks";
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectInstanceExtensions.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectInstanceExtensions.cs
@@ -1,0 +1,44 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ProjectInstanceExtensions.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+
+using Microsoft.Build.Execution;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    internal static class ProjectInstanceExtensions
+    {
+        public static T? GetPropertyAs<T>(this ProjectInstance self, string name, T? defaultValue = null)
+            where T : struct
+        {
+            var prop = self.GetProperty(name);
+            return prop is null ? defaultValue : (T?)Convert.ChangeType(prop.EvaluatedValue, typeof(T), CultureInfo.InvariantCulture);
+        }
+
+        public static string? GetOptionalProperty(this ProjectInstance self, string name, string? defaultValue = null)
+        {
+            var prop = self.GetProperty(name);
+            return prop is null ? defaultValue : prop.EvaluatedValue;
+        }
+
+        // Sadly, project creator library doesn't have support for after build state retrieval...
+        // Fortunately, it is fairly easy to create an extension to handle that scenario.
+        public static BuildResult Build(this ProjectInstance self, params string[] targetsToBuild)
+        {
+            return BuildManager.DefaultBuildManager.Build(
+                                    new BuildParameters(),
+                                    new BuildRequestData(
+                                        self,
+                                        targetsToBuild,
+                                        new HostServices(),
+                                        BuildRequestDataFlags.ProvideProjectStateAfterBuild
+                                        )
+                                    );
+        }
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ReadMe.md
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ReadMe.md
@@ -1,0 +1,11 @@
+# About
+This library handles testing of the build tasks. It does so, by manually constructing test
+projects that include a package reference to the Build tasks (as a real world consumer would do).
+It controls global properties, resolves the NuGet references, and then runs the task
+'PrepareVersioningForBuild'. This is all made plausible by the MSBuild evaluation libraries in
+combination with the [MSBuild ProjectCreator](https://github.com/jeffkl/MSBuildProjectCreator)
+library.
+
+Directly controlling the build using these libraries allows multiple test runs with different
+parameters/options to validate all the flexibility offered by the tests. By validating the actual
+package it validates what a real world consumer will use and not something "faked".

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/TestModuleFixtures.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/TestModuleFixtures.cs
@@ -5,7 +5,6 @@
 // -----------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 
@@ -26,17 +25,15 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
             ArgumentNullException.ThrowIfNull( ctx );
             ArgumentException.ThrowIfNullOrWhiteSpace( ctx.TestRunDirectory );
 
-            MSBuildAssemblyResolver.Register();
-
             // This assumes the solutions '.runsettings' file has re-directed the run output
             // to a well known location. There's no way to "pass" in the location to the build
             // of this test.
             string buildOutputPath = Path.GetFullPath( Path.Combine(ctx.TestRunDirectory, "..", ".."));
-
             string buildRoot = Path.GetFullPath( Path.Combine(buildOutputPath, ".."));
 
-            // Generate a fake directory.build.[props|targets] in the test run directory to prevent MSBUILD
-            // from searching beyond these to find the REPO one in the root.
+            // Generate fake directory.build.[props|targets] in the test run directory to prevent MSBUILD
+            // from searching beyond these to find the REPO one in the root (It contains things that will
+            // interfere with deterministic testing).
             ProjectCreator.Create()
                           .Save( Path.Combine( ctx.TestRunDirectory, "Directory.Build.props" ) );
 
@@ -44,35 +41,23 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
                           .Save( Path.Combine( ctx.TestRunDirectory, "Directory.Build.targets" ) );
 
             // Ensure environment is clear of any overrides to ensure tests are validating the correct behavior
-            // Individual tests MAY NOT set these again see remarks below for details. But there is currently,
-            // no consistent mechanism for controlling the set of variables provided to child processes for
-            // the build of created projects.
-            bool hasBadVars = false;
+            // Individual tests MAY set these again. To prevent interference with other tests, any such test
+            // needing to set these must restore them (even on exceptional exit) via a try/finally or using pattern.
             foreach(string envVar in TaskInputPropertyNames)
             {
                 string? value = Environment.GetEnvironmentVariable(envVar);
-                if( value is not null)
+                if(value is not null)
                 {
-                    ctx.WriteLine($"ENV VAR SET: {envVar}");
-                    hasBadVars = true;
+                    Environment.SetEnvironmentVariable(envVar, null);
                 }
-            }
-
-            if (hasBadVars)
-            {
-                // Sadly, setting the bad env vars to null doesn't have any impact on the way that build generates the
-                // child processes. (Even worse is that it wouldn't have ANY impact under non-windows systems as those
-                // clone the environment locally and only impact the clone, you'd need to explicitly provide the env
-                // for ALL child processes)
-                throw new InvalidOperationException("Overriding environment variables exist, tests will NOT run correctly");
             }
 
             // Nuget.Config is written to the root path, so this folder must be a parent of the
             // test project files or the settings will NOT apply!
             PackageRepo = PackageRepository.Create(
                 ctx.TestRunDirectory,                            // '.nuget/packages' repo folder goes here
-                new Uri(Path.Combine(buildOutputPath, "NuGet")), // Local feed (Contains location of the build of the package under test)
-                new Uri("https://api.nuget.org/v3/index.json") // standard NuGet Feed
+                new Uri( Path.Combine( buildOutputPath, "NuGet" ) ), // Local feed (Contains location of the build of the package under test)
+                new Uri( "https://api.nuget.org/v3/index.json" ) // standard NuGet Feed
             );
         }
 
@@ -87,7 +72,6 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
             File.Copy(Path.Combine(srcDir, fileName), Path.Combine(dstDir, fileName), overwrite: true);
         }
 
-        // internal static string? OldEnvNugetPackages { get; private set; }
         private static PackageRepository? PackageRepo;
 
         private static readonly ImmutableArray<string> TaskInputPropertyNames = [

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/TestModuleFixtures.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/TestModuleFixtures.cs
@@ -1,0 +1,108 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="TestModuleFixtures.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+
+using Microsoft.Build.Utilities.ProjectCreation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    // Provides common location for one time initialization for all tests in this assembly
+    // Doing the package repo construction here, allows tests to run in parallel without
+    // hitting access denied errors due to the use of the location in some other test.
+    [TestClass]
+    public static class TestModuleFixtures
+    {
+        [AssemblyInitialize]
+        public static void AssemblyInitialize( TestContext ctx )
+        {
+            ArgumentNullException.ThrowIfNull( ctx );
+            ArgumentException.ThrowIfNullOrWhiteSpace( ctx.TestRunDirectory );
+
+            MSBuildAssemblyResolver.Register();
+
+            // This assumes the solutions '.runsettings' file has re-directed the run output
+            // to a well known location. There's no way to "pass" in the location to the build
+            // of this test.
+            string buildOutputPath = Path.GetFullPath( Path.Combine(ctx.TestRunDirectory, "..", ".."));
+
+            string buildRoot = Path.GetFullPath( Path.Combine(buildOutputPath, ".."));
+
+            // Generate a fake directory.build.[props|targets] in the test run directory to prevent MSBUILD
+            // from searching beyond these to find the REPO one in the root.
+            ProjectCreator.Create()
+                          .Save( Path.Combine( ctx.TestRunDirectory, "Directory.Build.props" ) );
+
+            ProjectCreator.Create()
+                          .Save( Path.Combine( ctx.TestRunDirectory, "Directory.Build.targets" ) );
+
+            // Ensure environment is clear of any overrides to ensure tests are validating the correct behavior
+            // Individual tests MAY NOT set these again see remarks below for details. But there is currently,
+            // no consistent mechanism for controlling the set of variables provided to child processes for
+            // the build of created projects.
+            bool hasBadVars = false;
+            foreach(string envVar in TaskInputPropertyNames)
+            {
+                string? value = Environment.GetEnvironmentVariable(envVar);
+                if( value is not null)
+                {
+                    ctx.WriteLine($"ENV VAR SET: {envVar}");
+                    hasBadVars = true;
+                }
+            }
+
+            if (hasBadVars)
+            {
+                // Sadly, setting the bad env vars to null doesn't have any impact on the way that build generates the
+                // child processes. (Even worse is that it wouldn't have ANY impact under non-windows systems as those
+                // clone the environment locally and only impact the clone, you'd need to explicitly provide the env
+                // for ALL child processes)
+                throw new InvalidOperationException("Overriding environment variables exist, tests will NOT run correctly");
+            }
+
+            // Nuget.Config is written to the root path, so this folder must be a parent of the
+            // test project files or the settings will NOT apply!
+            PackageRepo = PackageRepository.Create(
+                ctx.TestRunDirectory,                            // '.nuget/packages' repo folder goes here
+                new Uri(Path.Combine(buildOutputPath, "NuGet")), // Local feed (Contains location of the build of the package under test)
+                new Uri("https://api.nuget.org/v3/index.json") // standard NuGet Feed
+            );
+        }
+
+        [AssemblyCleanup]
+        public static void AssemblyCleanup( )
+        {
+            PackageRepo?.Dispose();
+        }
+
+        private static void CopyFile(string srcDir, string fileName, string dstDir)
+        {
+            File.Copy(Path.Combine(srcDir, fileName), Path.Combine(dstDir, fileName), overwrite: true);
+        }
+
+        // internal static string? OldEnvNugetPackages { get; private set; }
+        private static PackageRepository? PackageRepo;
+
+        private static readonly ImmutableArray<string> TaskInputPropertyNames = [
+            "BuildTime",
+            "IsPullRequestBuild",
+            "IsAutomatedBuild",
+            "IsReleaseBuild",
+            "CiBuildIndex",
+            "CiBuildName",
+            "BuildVersionXml",
+            "BuildMajor",
+            "FullBuildNumber",
+            "FileVersion",
+            "AssemblyVersion",
+            "InformationalVersion"
+        ];
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/Ubiquity.Versioning.Build.Tasks.UT.csproj
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/Ubiquity.Versioning.Build.Tasks.UT.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+      <TargetFramework>net9.0</TargetFramework>
+      <IsPackable>false</IsPackable>
+      <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+      <IsCiBuild>true</IsCiBuild>
+      <IsCiBuild Condition="'$(IsReleaseBuild)'=='true'">false</IsCiBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" />
+      <PackageReference Include="MSBuild.ProjectCreation" />
+      <PackageReference Include="MSTest.TestFramework" />
+      <PackageReference Include="MSTest.TestAdapter" />
+  </ItemGroup>
+</Project>

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/Ubiquity.Versioning.Build.Tasks.UT.csproj
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/Ubiquity.Versioning.Build.Tasks.UT.csproj
@@ -2,9 +2,6 @@
   <PropertyGroup>
       <TargetFramework>net9.0</TargetFramework>
       <IsPackable>false</IsPackable>
-      <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-      <IsCiBuild>true</IsCiBuild>
-      <IsCiBuild Condition="'$(IsReleaseBuild)'=='true'">false</IsCiBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/stylecop.json
+++ b/stylecop.json
@@ -11,7 +11,7 @@
         "namingRules":
         {
             "allowCommonHungarianPrefixes": false,
-            "allowedHungarianPrefixes": ["h", "di", "op", "os", "ir", "is", "do", "un", "on", "to", "if", "no", "v","in"]
+            "allowedHungarianPrefixes": ["h", "di", "op", "os", "ir", "is", "do", "un", "on", "to", "if", "no", "v", "in", "p", "ci"]
         },
         "orderingRules":
         {


### PR DESCRIPTION
This is a major re-write of the tasks to allow testing of the various elements more directly.
* Builds a tested standalone lib for dealing with semvers
* Builds the tasks as a distinct package with no dependencies
* Handles defining the version for the binaries produced in this repo
    - Tests that the results of such versioning matches expectations of the task.