### PR TITLE
Potential fix for code scanning alerts: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2
-        if: ${{  github.event_name == "push" }}
+        if: ${{  github.event_name == 'push' }}
         with:
           files: BuildOutput/Test-Results/*.trx
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,4 +1,6 @@
 name: CI-Build
+permissions:
+  contents: read
 defaults:
     run:
         shell: pwsh

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2
+        if: ${{  github.event_name == "push" }}
         with:
           files: BuildOutput/Test-Results/*.trx
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,4 +1,9 @@
 name: Release-Build
+permissions:
+  contents: write
+  pages: write
+  packages: write
+  actions: read
 defaults:
   run:
     shell: pwsh


### PR DESCRIPTION
Potential fix for [https://github.com/UbiquityDotNET/CSemVer.GitBuild/security/code-scanning/1](https://github.com/UbiquityDotNET/CSemVer.GitBuild/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `contents: write` for committing documentation changes.
- `pages: write` for pushing documentation to GitHub Pages.
- `packages: write` for publishing packages to NuGet.org.
- `actions: read` for interacting with GitHub Actions artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to individual jobs if different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
