### PR TITLE
Re-worked PR/CI build support

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -23,6 +23,17 @@ on:
       - '**.dic'
 
 jobs:
+  # see: https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#support-fork-repositories-and-dependabot-branches
+  event_file:
+    name: "Event File"
+    runs-on: windows-latest
+    steps:
+      - name: Upload event file
+        uses: actions/upload-artifact@v4
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
+
   build_target:
     runs-on: windows-latest
     steps:
@@ -38,10 +49,15 @@ jobs:
       - name: Run Tests
         run: ./Invoke-Tests.ps1
 
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: Test Results
+          path: BuildOutput/Test-Results/*.trx
+
       - name: Upload NuGET Packages
         uses: actions/upload-artifact@v4
         with:
-            name: Build Results
-            path: |
-              ./BuildOutput/NuGet
-              BuildOutput/Test-Results/*.trx
+            name: NuGet Packages
+            path: ./BuildOutput/NuGet
+

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,14 +38,10 @@ jobs:
       - name: Run Tests
         run: ./Invoke-Tests.ps1
 
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action/windows@v2
-        if: ${{  github.event_name == 'push' }}
-        with:
-          files: BuildOutput/Test-Results/*.trx
-
       - name: Upload NuGET Packages
         uses: actions/upload-artifact@v4
         with:
-            name: Nuget Packages
-            path: ./BuildOutput/NuGet
+            name: Build Results
+            path: |
+              ./BuildOutput/NuGet
+              BuildOutput/Test-Results/*.trx

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,43 @@
+name: Test Results
+
+on:
+  workflow_run:
+    workflows: ["CI-Build"]
+    types:
+      - completed
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure'
+
+    permissions:
+      checks: write
+
+      # needed unless run with comment_mode: off
+      pull-requests: write
+
+      # only needed for private repository
+      #contents: read
+      # only needed for private repository
+      #issues: read
+
+      # required by download step to access artifacts API
+      actions: read
+
+    steps:
+      - name: Download and Extract Artifacts
+        uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d
+        with:
+           run_id: ${{ github.event.workflow_run.id }}
+           path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
Re-worked build support to allow publication of test runs for forked repos. For full details see: https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#support-fork-repositories-and-dependabot-branches