### PR TITLE
Added support for CSemVer v1.0.0-rc.1 pre-release formatting

### DIFF
--- a/Show-Docs.ps1
+++ b/Show-Docs.ps1
@@ -5,20 +5,17 @@ using module "PSModules/RepoBuild/RepoBuild.psd1"
 .SYNOPSIS
     Shows docs using the docfx built-in server
 
-.PARAMETER DocsPathToHost
-    Path of docs to host. Default is the local build but any legit path is accepted.
-    This is useful when downloading docs build artifacts to ensure they are built correctly.
-
 .PARAMETER buildInfo
    BuildInfo to use for current repo build. The hashtable provided for this must include the
    `DocsOutputPath` value for the path to use. This is normally set by a call to `Initialize-Environment`
+
+.PARAMETER DocsPathToHost
+    Path of docs to host. Default is the local build but any legit path is accepted.
+    This is useful when downloading docs build artifacts to ensure they are built correctly.
 #>
 Param(
-    [Parameter(Mandatory, ParameterSetName = 'UsePath', Position = 0)]
-    [string]$DocsPathToHost,
-
-    [Parameter(ParameterSetName = 'UseRepo', Position = 0)]
-    [hashtable]$buildInfo
+    [hashtable]$buildInfo,
+    [string]$DocsPathToHost
 )
 
 $docFXToolVersion = '2.78.3'
@@ -30,7 +27,7 @@ Push-Location $PSScriptRoot
 $oldPath = $env:Path
 try
 {
-    if ($PSCmdlet.ParameterSetName -eq 'UseRepo')
+    if (!$DocsPathToHost)
     {
         if (!$buildInfo)
         {

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.targets
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.targets
@@ -54,11 +54,11 @@
                            BuildMeta = "$(BuildMeta)"
                            >
             <Output TaskParameter="CSemVer" PropertyName="FullBuildNumber" />
+            <Output TaskParameter="ShortCSemVer" PropertyName="ShortBuildNumber"/>
             <Output TaskParameter="FileVersionMajor" PropertyName="FileVersionMajor" />
             <Output TaskParameter="FileVersionMinor" PropertyName="FileVersionMinor" />
             <Output TaskParameter="FileVersionBuild" PropertyName="FileVersionBuild" />
             <Output TaskParameter="FileVersionRevision" PropertyName="FileVersionRevision" />
-            <Output TaskParameter="ShortCSemVer" PropertyName="PackageVersion"/>
         </CreateVersionInfo>
     </Target>
 
@@ -68,6 +68,12 @@
             <FileVersion Condition="'$(FileVersion)'==''">$(__FileVersion)</FileVersion>
             <AssemblyVersion Condition="'$(AssemblyVersion)'==''">$(__FileVersion)</AssemblyVersion>
             <InformationalVersion Condition="$(InformationalVersion)==''">$(FullBuildNumber)</InformationalVersion>
+            <!--
+            NuGet clients prior to 4.3.0 don't support the full name, and instead should use the short name.
+            Default is to use the newer format, but allow specification of the legacy format if needed.
+            -->
+            <PackageVersion Condition="$(FullBuildNumber)!='' AND '$(PackageVersionUsesShortForm)'!='true'">$(FullBuildNumber)</PackageVersion>
+            <PackageVersion Condition="$(ShortBuildNumber)!='' AND '$(PackageVersionUsesShortForm)'=='true'">$(ShortBuildNumber)</PackageVersion>
         </PropertyGroup>
     </Target>
 

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
@@ -92,13 +92,13 @@ namespace Ubiquity.NET.Versioning.UT
 
             // Validate ToString("S") P=1; CI=0
             Assert.AreEqual("20.1.4-a", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("S", null));
-            Assert.AreEqual("20.1.4-b.1", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("S", null));
-            Assert.AreEqual("20.1.4-d.0.1", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-b01", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-d00-01", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("S", null));
 
             // Validate ToString("S") P=1; CI=1
             Assert.AreEqual("20.1.4-a.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("S", null));
-            Assert.AreEqual("20.1.4-b.1.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("S", null));
-            Assert.AreEqual("20.1.4-d.0.1.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-b01.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("S", null));
+            Assert.AreEqual("20.1.4-d00-01.ci.BuildIndex.BuildName", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("S", null));
 
             // Validate ToString("MS") P=0; CI=0
             Assert.AreEqual("20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("MS", null));
@@ -108,13 +108,13 @@ namespace Ubiquity.NET.Versioning.UT
 
             // Validate ToString("S") P=1; CI=0
             Assert.AreEqual("20.1.4-a+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("MS", null));
-            Assert.AreEqual("20.1.4-b.1+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("MS", null));
-            Assert.AreEqual("20.1.4-d.0.1+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-b01+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-d00-01+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("MS", null));
 
             // Validate ToString("S") P=1; CI=1
             Assert.AreEqual("20.1.4-a.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("MS", null));
-            Assert.AreEqual("20.1.4-b.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("MS", null));
-            Assert.AreEqual("20.1.4-d.0.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-b01.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("MS", null));
+            Assert.AreEqual("20.1.4-d00-01.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("MS", null));
 
             // Validate ToString("SM") P=0; CI=0
             Assert.AreEqual("20.1.4+buildMeta", new CSemVer(20, 1, 4, default, default, "buildMeta").ToString("SM", null));
@@ -124,13 +124,13 @@ namespace Ubiquity.NET.Versioning.UT
 
             // Validate ToString("S") P=1; CI=0
             Assert.AreEqual("20.1.4-a+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, default, "buildMeta").ToString("SM", null));
-            Assert.AreEqual("20.1.4-b.1+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("SM", null));
-            Assert.AreEqual("20.1.4-d.0.1+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-b01+buildMeta", new CSemVer(20, 1, 4, beta_1_0, default, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-d00-01+buildMeta", new CSemVer(20, 1, 4, delta_0_1, default, "buildMeta").ToString("SM", null));
 
             // Validate ToString("S") P=1; CI=1
             Assert.AreEqual("20.1.4-a.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, alpha_0_0, ciInfo, "buildMeta").ToString("SM", null));
-            Assert.AreEqual("20.1.4-b.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("SM", null));
-            Assert.AreEqual("20.1.4-d.0.1.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-b01.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, beta_1_0, ciInfo, "buildMeta").ToString("SM", null));
+            Assert.AreEqual("20.1.4-d00-01.ci.BuildIndex.BuildName+buildMeta", new CSemVer(20, 1, 4, delta_0_1, ciInfo, "buildMeta").ToString("SM", null));
         }
 
         [TestMethod]

--- a/src/Ubiquity.NET.Versioning.UT/PrereleaseVersionTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/PrereleaseVersionTests.cs
@@ -79,11 +79,11 @@ namespace Ubiquity.NET.Versioning.Tests
             Assert.AreEqual("-alpha.1", prv.ToString());
 
             prv = new PrereleaseVersion( "beta", 1, 0);
-            Assert.AreEqual("-b.1",prv.ToString("S", null));
+            Assert.AreEqual("-b01",prv.ToString("S", null));
 
             // The Z format is used when there is CI build info available
             Assert.AreEqual("-beta.1.0",prv.ToString("Z", null));
-            Assert.AreEqual("-b.1.0",prv.ToString("SZ", null), "format combinations are allowed");
+            Assert.AreEqual("-b01-00",prv.ToString("SZ", null), "format combinations are allowed");
         }
     }
 }

--- a/src/Ubiquity.NET.Versioning/PrereleaseVersion.cs
+++ b/src/Ubiquity.NET.Versioning/PrereleaseVersion.cs
@@ -110,7 +110,8 @@ namespace Ubiquity.NET.Versioning
         /// <item><term>S</term><description>Use short form of pre-release name</description></item>
         /// <item><term>Z</term><description>Assume a CI build and ALWAYs include 0 values for <see cref="Number"/> and <see cref="Fix"/></description></item>
         /// </list>
-        /// The 'F' and 'S' are mutually exclusive values, only ONE of them at a time is valid. 'Z' is allowed in combination with either or alone.
+        /// The 'F' and 'S' are mutually exclusive values, only ONE of them at a time is valid. 'Z' is allowed in combination with either or alone and
+        /// used to support legacy formatting where the zero value is always included for short forms (CSemVer v1.0.0-rc.1 does NOT include that)
         /// </remarks>
         public string ToString( string? format, IFormatProvider? formatProvider )
         {
@@ -149,10 +150,10 @@ namespace Ubiquity.NET.Versioning
 
             if(Number > 0 || Fix > 0 || alwaysIncludeZero)
             {
-                bldr.AppendFormat( CultureInfo.InvariantCulture, ".{0}", Number );
+                bldr.AppendFormat( CultureInfo.InvariantCulture, useShortForm ? "{0:D02}" : ".{0}", Number );
                 if(Fix > 0 || alwaysIncludeZero)
                 {
-                    bldr.AppendFormat( CultureInfo.InvariantCulture, ".{0}", Fix );
+                    bldr.AppendFormat( CultureInfo.InvariantCulture, useShortForm ? "-{0:D02}" : ".{0}", Fix );
                 }
             }
 


### PR DESCRIPTION
Added support for CSemVer v1.0.0-rc.1 pre-release formatting
In This version the pre-release formatting for a short form string is different. It follows the same rules about a 0 value but has no leading delimiter AND uses a 2 decimal digit format with a dash as the delimiter.
* updated docs