### PR TITLE
Converted to using long from for package name

### DIFF
--- a/New-GeneratedVersionProps.ps1
+++ b/New-GeneratedVersionProps.ps1
@@ -339,11 +339,11 @@ try
     $propGroupElement.AppendChild($fileVersionElement) | Out-Null
 
     $packageVersionElement = $xmlDoc.CreateElement('PackageVersion')
-    $packageVersionElement.InnerText = $csemVer.ToString($false,$true) # short form of version
+    $packageVersionElement.InnerText = $csemVer.ToString($false,$false) # long form of version (No metadata)
     $propGroupElement.AppendChild($packageVersionElement) | Out-Null
 
     $productVersionElement = $xmlDoc.CreateElement('ProductVersion')
-    $productVersionElement.InnerText = $csemVer.ToString($true, $false) # long form of version
+    $productVersionElement.InnerText = $csemVer.ToString($true, $false) # long form of version (With metadata)
     $propGroupElement.AppendChild($productVersionElement) | Out-Null
 
     $assemblyVersionElement = $xmlDoc.CreateElement('AssemblyVersion')

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/CreateVersionInfo.cs
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/CreateVersionInfo.cs
@@ -168,7 +168,7 @@ namespace Ubiquity.NET.Versioning.Build.Tasks
                 orderedVersion += (ulong)PreReleaseFix;
             }
 
-            Log.LogMessage(MessageImportance.High, "orderedVersion={0}", orderedVersion);
+            Log.LogMessage(MessageImportance.Low, "orderedVersion={0}", orderedVersion);
 
             bool isCiBuild = !string.IsNullOrWhiteSpace(CiBuildIndex) && !string.IsNullOrWhiteSpace(CiBuildName);
             UInt64 fileVersion64 = (orderedVersion << 1) + (isCiBuild ? 1ul : 0ul);
@@ -183,10 +183,10 @@ namespace Ubiquity.NET.Versioning.Build.Tasks
             rem = (rem - FileVersionMinor.Value) / 65536;
             FileVersionMajor = (UInt16)(rem % 65536);
 
-            Log.LogMessage(MessageImportance.High, "FileVersionMajor={0}", FileVersionMajor);
-            Log.LogMessage(MessageImportance.High, "FileVersionMinor={0}", FileVersionMinor);
-            Log.LogMessage(MessageImportance.High, "FileVersionBuild={0}", FileVersionBuild);
-            Log.LogMessage(MessageImportance.High, "FileVersionRevision={0}", FileVersionRevision);
+            Log.LogMessage(MessageImportance.Low, "FileVersionMajor={0}", FileVersionMajor);
+            Log.LogMessage(MessageImportance.Low, "FileVersionMinor={0}", FileVersionMinor);
+            Log.LogMessage(MessageImportance.Low, "FileVersionBuild={0}", FileVersionBuild);
+            Log.LogMessage(MessageImportance.Low, "FileVersionRevision={0}", FileVersionRevision);
         }
 
         private bool ValidateInput( )


### PR DESCRIPTION
Converted to using long from for package name
* Modern client support the long form now.
* Reduced noisy output as some messages were still left at "high" importance