### PR TITLE
Fixed release build scripts

### DIFF
--- a/New-GeneratedVersionProps.ps1
+++ b/New-GeneratedVersionProps.ps1
@@ -196,8 +196,6 @@ class CSemVer
 
         $this.BuildMetadata = $buildVersionData['BuildMetadata']
 
-        $this.CiBuildName = $buildVersionData['CiBuildName'];
-        $this.CiBuildIndex = $buildVersionData['CiBuildIndex'];
 
         if( (![string]::IsNullOrEmpty( $this.CiBuildName )) -and [string]::IsNullOrEmpty( $this.CiBuildIndex ) )
         {
@@ -207,6 +205,12 @@ class CSemVer
         if( (![string]::IsNullOrEmpty( $this.CiBuildIndex )) -and [string]::IsNullOrEmpty( $this.CiBuildName ) )
         {
             throw 'CiBuildName is required if CiBuildIndex is provided';
+        }
+
+        if( ![string]::IsNullOrEmpty( $this.CiBuildIndex ) -and ![string]::IsNullOrEmpty( $this.CiBuildName ) )
+        {
+            $this.CiBuildName = $buildVersionData['CiBuildName'];
+            $this.CiBuildIndex = $buildVersionData['CiBuildIndex'];
         }
 
         $this.OrderedVersion = [CSemVer]::GetOrderedVersion($this.Major, $this.Minor, $this.Patch, $this.PreReleaseVersion)

--- a/OneFlow/Publish-Release.ps1
+++ b/OneFlow/Publish-Release.ps1
@@ -36,7 +36,7 @@ Write-Information 'Fetching from official repository'
 Invoke-External git fetch $officialRemoteName
 
 Write-Information "Switching to release branch [$officialReleaseBranch]"
-Invoke-External git switch '-c' $releasebranch $officialReleaseBranch
+Invoke-External git switch '-C' $releasebranch $officialReleaseBranch
 
 Write-Information 'Creating tag of this branch as the release'
 Invoke-External git tag $tagname '-m' "Official release: $tagname"


### PR DESCRIPTION
Fixed release build scripts
* Publish release now resets the branch if it exists
* Fixed generation of version info to not include CI information for a release build as it will be null