### PR TITLE
Updated test access to build environment information.

### DIFF
--- a/End-FakeReleaseBuild.ps1
+++ b/End-FakeReleaseBuild.ps1
@@ -1,0 +1,3 @@
+$env:CLI=$null
+$env:GITHUB_ACTIONS=$null
+$env:GITHUB_REF=$null

--- a/New-GeneratedVersionProps.ps1
+++ b/New-GeneratedVersionProps.ps1
@@ -358,6 +358,13 @@ try
     $informationalVersionElement.InnerText = $csemVer.ToString($true, $false) # long form of version
     $propGroupElement.AppendChild($informationalVersionElement) | Out-Null
 
+    # inform unit testing of the environment as the env vars are NOT accessible to the tests
+    # Sadly, the `dotnet test` command does not spawn the tests with an inherited environment.
+    # So they cannot know what the scenario is.
+    $buildKindElement = $xmlDoc.CreateElement('BuildKind')
+    $buildKindElement.InnerText = $buildKind
+    $propGroupElement.AppendChild($buildKindElement) | Out-Null
+
     # Unit tests need to see the CI build info as it isn't something they can determine on their own.
     # The Build index is based on a timestamp and the build name depends on the runtime environment
     # to set some env vars etc...
@@ -375,7 +382,6 @@ try
         $ciBuildNameElement.InnerText = $verInfo['CiBuildName']
         $propGroupElement.AppendChild($ciBuildNameElement) | Out-Null
     }
-
     $buildGeneratedPropsPath = Join-Path $buildInfo['RepoRootPath'] 'GeneratedVersion.props'
     $xmlDoc.Save($buildGeneratedPropsPath)
 }

--- a/Start-FakeReleaseBuild.ps1
+++ b/Start-FakeReleaseBuild.ps1
@@ -1,0 +1,4 @@
+# Fake Release build
+$env:CLI="true"
+$env:GITHUB_ACTIONS="true"
+$env:GITHUB_REF="refs/tags/v5.0.0.rc"

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.props
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.props
@@ -20,6 +20,12 @@
         <CiBuildName Condition="'$(CiBuildName)'=='' AND $(IsPullRequestBuild) AND !$(IsReleaseBuild)">PRQ</CiBuildName>
         <CiBuildName Condition="'$(CiBuildName)'=='' AND $(IsAutomatedBuild) AND !$(IsReleaseBuild)">BLD</CiBuildName>
         <CiBuildName Condition="'$(CiBuildName)'=='' AND !$(IsReleaseBuild)">ZZZ</CiBuildName>
+    </PropertyGroup>
 
+    <!-- Force empty values for CI Build info in a release build -->
+    <PropertyGroup Condition="$(IsReleaseBuild)">
+        <CiBuildName/>
+        <CiBuildIndex />
+        <BuildTime />
     </PropertyGroup>
 </Project>

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/TestUtils.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/TestUtils.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 
 using Microsoft.Build.Definition;
@@ -13,7 +15,7 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
 {
     internal static class TestUtils
     {
-        internal static (string CiBuildIndex, string CiBuildName, string BuildTime) GetGeneratedCiBuildInfo( )
+        internal static (string CiBuildIndex, string CiBuildName, string BuildTime, IDisposable EnvControl) GetGeneratedBuildInfo( )
         {
             using var dummyCollection = new ProjectCollection();
             var options = new ProjectOptions()
@@ -22,7 +24,63 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
             };
 
             var project = Project.FromFile(Path.Combine(TestModuleFixtures.RepoRoot, "GeneratedVersion.props"), options);
-            return (project.GetPropertyValue("CiBuildIndex"), project.GetPropertyValue("CiBuildName"), project.GetPropertyValue("BuildTime"));
+
+            return (
+                project.GetPropertyValue( "CiBuildIndex" ),
+                project.GetPropertyValue( "CiBuildName" ),
+                project.GetPropertyValue( "BuildTime" ),
+                project.SetEnvFromGeneratedVersionInfo()
+                );
+        }
+
+        [SuppressMessage( "Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "Not possible, file scoped type" )]
+        private static IDisposable SetEnvFromGeneratedVersionInfo( this Project project )
+        {
+            // Reset-environment variables for this test process based on the build-kind set by build scripts
+            // This is needed as the tests don't inherit the environment of the command that runs them.
+            switch(project.GetPropertyValue( "BuildKind" ))
+            {
+            case "LocalBuild":
+                Environment.SetEnvironmentVariable( "IsAutomatedBuild", "false" );
+                Environment.SetEnvironmentVariable( "IsPullRequestBuild", "false" );
+                Environment.SetEnvironmentVariable( "IsReleaseBuild", "false" );
+                break;
+
+            case "PullRequestBuild":
+                Environment.SetEnvironmentVariable( "IsAutomatedBuild", "true" );
+                Environment.SetEnvironmentVariable( "IsPullRequestBuild", "true" );
+                Environment.SetEnvironmentVariable( "IsReleaseBuild", "false" );
+                break;
+
+            case "CiBuild":
+                Environment.SetEnvironmentVariable( "IsAutomatedBuild", "true" );
+                Environment.SetEnvironmentVariable( "IsPullRequestBuild", "false" );
+                Environment.SetEnvironmentVariable( "IsReleaseBuild", "false" );
+                break;
+
+            case "ReleaseBuild":
+                Environment.SetEnvironmentVariable( "IsAutomatedBuild", "true" );
+                Environment.SetEnvironmentVariable( "IsPullRequestBuild", "false" );
+                Environment.SetEnvironmentVariable( "IsReleaseBuild", "true" );
+                break;
+
+            default:
+                throw new InvalidOperationException( "Unknown build kind in GeneratedVersion.props" );
+            }
+
+            return new ResetEnv();
+        }
+    }
+
+    [SuppressMessage( "StyleCop.CSharp.MaintainabilityRules", "SA1402:File may only contain a single type", Justification = "DUH! It's file scoped!" )]
+    file sealed class ResetEnv
+        : IDisposable
+    {
+        public void Dispose( )
+        {
+            Environment.SetEnvironmentVariable( "IsAutomatedBuild", null );
+            Environment.SetEnvironmentVariable( "IsPullRequestBuild", null );
+            Environment.SetEnvironmentVariable( "IsReleaseBuild", null );
         }
     }
 }


### PR DESCRIPTION
Updated test access to build environment information.
Tests need access to the information about the environment to determine the correct versioning for a build. Normally, this is available in the Environment variables but test runs DO NOT get an inherited set of environment variables from the command that launched them.

* Added forcing CI info to blank in the task's props file
* Added setting of the environment variables with IDisposable RAII pattern to clean up afterwards when validating the as-built task assembly.
* Added [Start|End]-FakeReleaseBuild.ps1 scripts to aid in replicating a release build environment locally.
* Added BuildKind to the generatedVersion.props file to allow "communication" of the environment variables that existed at time of the task assembly build.