### PR TITLE
Added NuGet source mapping for unit tests.

### DIFF
--- a/src/Ubiquity.Versioning.Build.Tasks.UT/TestModuleFixtures.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/TestModuleFixtures.cs
@@ -63,7 +63,8 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
                 ctx.TestRunDirectory,                            // '.nuget/packages' repo folder goes here
                 new Uri(Path.Combine(BuildOutputPath, "NuGet")), // Local feed (Contains location of the build of the package under test)
                 new Uri("https://api.nuget.org/v3/index.json") // standard NuGet Feed
-            );
+            ).SourceMapping("Local1", "Ubiquity.NET.Versioning*") // force all fetches of built package to locally built source only
+             .SourceMapping("api.nuget.org", "*"); // Everything else goes to NuGet public feed.
         }
 
         [AssemblyCleanup]


### PR DESCRIPTION
Added NuGet source mapping for unit tests.
* Ensures that unit tests are using ONLY the locally built packages.
    - This wasn't a real issue until the first pre-release was published to public NuGet feeds