### PR TITLE
Added more testing and updated code based on results

### DIFF
--- a/docfx/build-tasks/index.md
+++ b/docfx/build-tasks/index.md
@@ -218,6 +218,8 @@ If not explicitly set this is determined by the automated build flags as describ
 section of this document.
 
 ## Detected Error Conditions
+
+### Targets file
 |Code    |Description|
 |--------|-----------|
 | CSM001 | BuildMajor is a required property, either set it as a global or in the build version XML |
@@ -227,14 +229,32 @@ section of this document.
 | CSM005 | FileVersion property not provided AND FileVersionMinor property not found to create it from |
 | CSM006 | FileVersion property not provided AND FileVersionBuild property not found to create it from |
 | CSM007 | FileVersion property not provided AND FileVersionRevision property not found to create it from |
+
+### CreateVersionInfo Task
+|Code    |Description|
+|--------|-----------|
 | CSM100 | BuildMajor value must be in range [0-99999] |
 | CSM101 | BuildMinor value must be in range [0-49999] |
 | CSM102 | BuildPatch value must be in range [0-9999] |
-| CSM103 | PreRelease Name is unknown |
+| CSM103 | PreReleaseName is unknown |
 | CSM104 | PreReleaseNumber value must be in range [0-99] |
-| CSM105 | If CiBuildIndex is set then CiBuildName must also be set; If CiBuildIndex is NOT set then CiBuildName must not be set. |
-| CSM106 | CiBuildIndex does not match syntax defined by CSemVer |
-| CSM107 | CiBuildName does not match syntax defined by CSemVer |
+| CSM105 | PreReleaseFix value must be in range [0-99] |
+| CSM106^1^ | If CiBuildIndex is set then CiBuildName must also be set; If CiBuildIndex is NOT set then CiBuildName must not be set. |
+| CSM107 | CiBuildIndex does not match syntax defined by CSemVer |
+| CSM108 | CiBuildName does not match syntax defined by CSemVer |
+
+### ParseBuildVersionXml Task
+|Code    |Description|
+|--------|-----------|
 | CSM200 | BuildVersionXml is required and must not be all whitespace |
 | CSM201 | Specified BuildVersionXml does not exist `$(BuildVersionXml)`|
-| CSM202 | [Warning] Unexpected attribute on BuildVersionData Element |
+| CSM202 | BuildVersionData element does not exist in `$(BuildVersionXml)`|
+| CSM203 | [Warning] Unexpected attribute on BuildVersionData Element |
+| CSM204 | XML format of file specified by `$(BuildVersionXml)' is invalid |
+
+----
+^1^ CSM106 is essentially an internal sanity test. The props/targets files ensure that
+`$(CiBuildIndex)` and `$(CiBuildName)` have a value unless $(IsReleaseBuild) is set. In that case
+the targets file will force them to empty. So, there's no way to test for or hit this condition
+without completely replacing/bypassing the props/targets files for the task. Which is obviously,
+an unsupported scenario :grin:.

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/CreateVersionInfo.cs
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/CreateVersionInfo.cs
@@ -221,35 +221,35 @@ namespace Ubiquity.NET.Versioning.Build.Tasks
                         hasInputError = true;
                     }
                 }
-            }
 
-            if(PreReleaseNumber < 0 || PreReleaseNumber > 99)
-            {
-                LogError("CSM104", "PreReleaseNumber value must be in range [0-99]" );
-                hasInputError = true;
-            }
+                if(PreReleaseNumber < 0 || PreReleaseNumber > 99)
+                {
+                    LogError("CSM104", "PreReleaseNumber value must be in range [0-99]" );
+                    hasInputError = true;
+                }
 
-            if(PreReleaseFix < 0 || PreReleaseFix > 99)
-            {
-                LogError("CSM104", "PreReleaseFix value must be in range [0-99]" );
-                hasInputError = true;
+                if(PreReleaseNumber != 0 && (PreReleaseFix < 0 || PreReleaseFix > 99))
+                {
+                    LogError("CSM105", "PreReleaseFix value must be in range [0-99]" );
+                    hasInputError = true;
+                }
             }
 
             if(string.IsNullOrWhiteSpace( CiBuildIndex ) != string.IsNullOrWhiteSpace( CiBuildName ))
             {
-                LogError("CSM105", "If CiBuildIndex is set then CiBuildName must also be set; If CiBuildIndex is NOT set then CiBuildName must not be set." );
+                LogError("CSM106", "If CiBuildIndex is set then CiBuildName must also be set; If CiBuildIndex is NOT set then CiBuildName must not be set." );
                 hasInputError = true;
             }
 
             if(CiBuildIndex != null && !CiBuildIdRegEx.IsMatch( CiBuildIndex ))
             {
-                LogError("CSM106", "CiBuildIndex does not match syntax defined by CSemVer" );
+                LogError("CSM107", "CiBuildIndex does not match syntax defined by CSemVer" );
                 hasInputError = true;
             }
 
             if(CiBuildName != null && !CiBuildIdRegEx.IsMatch( CiBuildName ))
             {
-                LogError("CSM107", "CiBuildName does not match syntax defined by CSemVer" );
+                LogError("CSM108", "CiBuildName does not match syntax defined by CSemVer" );
                 hasInputError = true;
             }
 

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.props
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.props
@@ -1,4 +1,4 @@
-﻿<Project>
+﻿<Project TreatAsLocalProperty="BuildTime;CiBuildName;IsPullRequestBuild;IsAutomatedBuild;IsReleaseBuild">
     <PropertyGroup>
         <!--
         Force the time-stamp into ISO 8601 format so it is locale neutral
@@ -20,12 +20,5 @@
         <CiBuildName Condition="'$(CiBuildName)'=='' AND $(IsPullRequestBuild) AND !$(IsReleaseBuild)">PRQ</CiBuildName>
         <CiBuildName Condition="'$(CiBuildName)'=='' AND $(IsAutomatedBuild) AND !$(IsReleaseBuild)">BLD</CiBuildName>
         <CiBuildName Condition="'$(CiBuildName)'=='' AND !$(IsReleaseBuild)">ZZZ</CiBuildName>
-    </PropertyGroup>
-
-    <!-- Force empty values for CI Build info in a release build -->
-    <PropertyGroup Condition="$(IsReleaseBuild)">
-        <CiBuildName/>
-        <CiBuildIndex />
-        <BuildTime />
     </PropertyGroup>
 </Project>

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.targets
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/build/Ubiquity.NET.Versioning.Build.Tasks.targets
@@ -1,8 +1,19 @@
-﻿<Project TreatAsLocalProperty="_TaskFolder;_Ubiquity_NET_Versioning_Build_Tasks;__FileVersion">
+﻿<Project TreatAsLocalProperty="_TaskFolder;_Ubiquity_NET_Versioning_Build_Tasks;__FileVersion;BuildTime;CiBuildIndex;CiBuildName">
     <PropertyGroup>
         <_TaskFolder Condition=" '$(MSBuildRuntimeType)' == 'Core' ">tasks\netstandard2.0\</_TaskFolder>
         <_TaskFolder Condition=" '$(MSBuildRuntimeType)' != 'Core' ">tasks\net48\</_TaskFolder>
         <_Ubiquity_NET_Versioning_Build_Tasks>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\$(_TaskFolder)Ubiquity.NET.Versioning.Build.Tasks.dll))</_Ubiquity_NET_Versioning_Build_Tasks>
+    </PropertyGroup>
+
+    <!--
+    Set empty values for CI Build info in a release build.
+    This must appear in the targets file to ensure that the properties are reset
+    AFTER any project might set them.
+    -->
+    <PropertyGroup Condition="$(IsReleaseBuild)">
+        <BuildTime/>
+        <CiBuildIndex/>
+        <CiBuildName/>
     </PropertyGroup>
 
     <UsingTask TaskName="CreateVersionInfo" AssemblyFile="$(_Ubiquity_NET_Versioning_Build_Tasks)"/>

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/AssemblyValidationTests.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/AssemblyValidationTests.cs
@@ -82,7 +82,8 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
 
                 using var collection = new ProjectCollection(globalProperties);
 
-                var (buildResults, props) = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+                using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+                var (buildResults, props) = fullResults;
                 LogBuildMessages(buildResults.Output);
                 Assert.IsTrue(buildResults.Success);
 

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/BuildTaskErrorTests.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/BuildTaskErrorTests.cs
@@ -1,0 +1,164 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BuildTaskErrorTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.Build.Evaluation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    [TestClass]
+    [TestCategory("Error Validation")]
+    public class BuildTaskErrorTests
+    {
+        public BuildTaskErrorTests( TestContext ctx )
+        {
+            ArgumentNullException.ThrowIfNull(ctx);
+            ArgumentException.ThrowIfNullOrWhiteSpace(ctx.TestResultsDirectory);
+
+            Context = ctx;
+        }
+
+        public TestContext Context { get; }
+
+        [TestMethod]
+        public void CSM001_Missing_BuildMajor_should_fail( )
+        {
+            // use a build version XML that has no attributes to get the expected error
+            // Otherwise, MSBUILD kicks in and complains about missing required param
+            string buildVersionXml = Context.CreateEmptyBuildVersionXmlWithRandomName();
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildVersionXml"] = buildVersionXml
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM001").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM002_Missing_BuildMinor_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "10"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM002").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM003_Missing_BuildPatch_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "10",
+                ["BuildMinor"] = "1",
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM003").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM004_Missing_FileVersionMajor_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "10",
+                ["BuildMinor"] = "1",
+                ["BuildPatch"] = "2",
+                ["FullBuildNumber"] = "\t", // Present but all whitespace; Presence of this skips the CreateVersionInfoTask
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM004").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM006_Missing_FileVersionMinor_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "10",
+                ["BuildMinor"] = "1",
+                ["BuildPatch"] = "2",
+                ["FullBuildNumber"] = "\t", // Present but all whitespace; Presence of this skips the CreateVersionInfoTask
+                ["FileVersionMajor"] = "1", // avoid CSM004 to allow testing of next field requirement
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM005").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM006_Missing_FileVersionBuild_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "10",
+                ["BuildMinor"] = "1",
+                ["BuildPatch"] = "2",
+                ["FullBuildNumber"] = "\t", // Present but all whitespace; Presence of this skips the CreateVersionInfoTask
+                ["FileVersionMajor"] = "1", // avoid CSM004 to allow testing of next field requirement
+                ["FileVersionMinor"] = "2", // avoid CSM005 to allow testing of next field requirement
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM006").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM007_Missing_FileVersionRevision_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "10",
+                ["BuildMinor"] = "1",
+                ["BuildPatch"] = "2",
+                ["FullBuildNumber"] = "\t", // Present but all whitespace; Presence of this skips the CreateVersionInfoTask
+                ["FileVersionMajor"] = "1", // avoid CSM004 to allow testing of next field requirement
+                ["FileVersionMinor"] = "2", // avoid CSM005 to allow testing of next field requirement
+                ["FileVersionBuild"] = "3", // avoid CSM006 to allow testing of next field requirement
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM007").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/BuildTaskTests.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/BuildTaskTests.cs
@@ -43,7 +43,8 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
             };
 
             using var collection = new ProjectCollection(globalProperties);
-            var (buildResults, props) = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+            var (buildResults, props) = fullResults;
             Assert.IsTrue(buildResults.Success);
 
             // v20.1.4-alpha => 5.44854.3875.59946 [see: https://csemver.org/playground/site/#/]
@@ -117,7 +118,8 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
 
             using var collection = new ProjectCollection(globalProperties);
 
-            var (buildResults, props) = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+            var (buildResults, props) = fullResults;
             Assert.IsTrue(buildResults.Success);
 
             // v20.1.5 => 5.44854.3880.52268 [see: https://csemver.org/playground/site/#/]
@@ -195,7 +197,8 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
             string expectedIndex = parsedBuildTime.ToBuildIndex();
 
             using var collection = new ProjectCollection(globalProperties);
-            var (buildResults, props) = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+            var (buildResults, props) = fullResults;
             Assert.IsTrue(buildResults.Success);
 
             // v20.1.5-delta.0.1 => 5.44854.3878.63342 [see: https://csemver.org/playground/site/#/]
@@ -278,7 +281,8 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
             string expectedIndex = parsedBuildTime.ToBuildIndex();
 
             using var collection = new ProjectCollection(globalProperties);
-            var (buildResults, props) = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage(targetFramework, collection);
+            var (buildResults, props) = fullResults;
             Assert.IsTrue(buildResults.Success);
 
             // v20.1.5-delta.1 => 5.44854.3878.63540 [see: https://csemver.org/playground/site/#/]
@@ -388,7 +392,8 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
             }
 
             using var collection = new ProjectCollection(globalProperties);
-            var (buildResults, props) = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
             Assert.IsTrue(buildResults.Success);
 
             FileVersionQuad expectedFileVersion = ExpectedFileVersion(isPreRelease, isCiBuild);

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/CreateVersionInfoTaskErrorTests.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/CreateVersionInfoTaskErrorTests.cs
@@ -1,0 +1,403 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="CreateVersionInfoTaskErrorTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Microsoft.Build.Evaluation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    [TestClass]
+    [TestCategory("Error Validation")]
+    public class CreateVersionInfoTaskErrorTests
+    {
+        public CreateVersionInfoTaskErrorTests( TestContext ctx )
+        {
+            ArgumentNullException.ThrowIfNull( ctx );
+            ArgumentException.ThrowIfNullOrWhiteSpace( ctx.TestResultsDirectory );
+
+            Context = ctx;
+        }
+
+        public TestContext Context { get; }
+
+        [TestMethod]
+        public void CSM100_BuildMajor_Negative_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "-1",
+                ["BuildMinor"] = "1",
+                ["BuildPatch"] = "2",
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM100").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM100_BuildMajor_too_large_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "100000",
+                ["BuildMinor"] = "1",
+                ["BuildPatch"] = "2",
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM100").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM101_BuildMinor_Negative_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "-1",
+                ["BuildPatch"] = "2",
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM101").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM101_BuildMinor_too_large_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "50000",
+                ["BuildPatch"] = "2",
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM101").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM102_BuildPatch_Negative_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "1",
+                ["BuildPatch"] = "-1",
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM102").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM102_BuildPatch_too_large_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "10000",
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM102").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM103_Unknown_PreReleaseName_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["PreReleaseName"] = "invalid" // not one of the 8 supported names...
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM103").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM104_PreReleaseNumber_Negative_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["PreReleaseName"] = "alpha",
+                ["PreReleaseNumber"] = "-1"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM104").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM104_PreReleaseNumber_too_large_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["PreReleaseName"] = "alpha",
+                ["PreReleaseNumber"] = "100"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM104").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void PreReleaseNumber_ignored_when_no_PreReleaseName( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+
+                // ["PreReleaseName"] = "alpha",
+                ["PreReleaseNumber"] = "100"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsTrue( buildResults.Success );
+        }
+
+        [TestMethod]
+        public void CSM105_PreReleaseFix_Negative_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["PreReleaseName"] = "alpha",
+                ["PreReleaseNumber"] = "1",
+                ["PreReleaseFix"] = "-1"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM105").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM105_PreReleaseFix_too_large_should_fail( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["PreReleaseName"] = "alpha",
+                ["PreReleaseNumber"] = "1",
+                ["PreReleaseFix"] = "100"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM105").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void PreReleaseFix_ignored_when_no_PreReleaseName( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+
+                // ["PreReleaseName"] = "alpha",
+                ["PreReleaseNumber"] = "1",
+                ["PreReleaseFix"] = "100"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsTrue( buildResults.Success );
+        }
+
+        [TestMethod]
+        public void PreReleaseFix_ignored_when_no_PreReleaseNumber( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["PreReleaseName"] = "alpha",
+
+                // ["PreReleaseNumber"] = "1",
+                ["PreReleaseFix"] = "100"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsTrue( buildResults.Success );
+        }
+
+#if CAN_FORCE_CSM106_SOMEHOW // see docs and IsReleaseBuild_forces_CI_properties_empty() test method
+        [TestMethod]
+        public void CSM106_When_only_CiBuildIndex_is_set( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["IsReleaseBuild"] = "true", // Bypasses props file setting of CiBuildName
+                ["CiBuildIndex"] = "ABC01234"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM106").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM106_When_only_CiBuildName_is_set( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["IsReleaseBuild"] = "true", // Bypasses props file setting of CiBuildName
+                ["CiBuildName"] = "01234ABC"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM106").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+#endif
+
+        [TestMethod]
+        public void IsReleaseBuild_forces_CI_properties_empty( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["IsReleaseBuild"] = "true", // Bypasses props file setting of CiBuildName; and forces it to clear the CI info
+                ["CiBuildIndex"] = "ABC01234", // targets file uses "TreatAsLocalProperty" to allow override/mutability of these
+                ["CiBuildName"] = "01234ABC",
+                ["BuildTime"] = DateTime.UtcNow.ToString("o")
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsTrue( buildResults.Success );
+            Assert.IsTrue( string.IsNullOrWhiteSpace( props.CiBuildIndex ) );
+            Assert.IsTrue( string.IsNullOrWhiteSpace( props.CiBuildName ) );
+            Assert.IsTrue( string.IsNullOrWhiteSpace( props.BuildTime ) );
+        }
+
+        [TestMethod]
+        public void CSM107_CiBuildIndex_has_bad_syntax( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["CiBuildIndex"] = "01234ABC="
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM107").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+
+        [TestMethod]
+        public void CSM108_CiBuildName_has_bad_syntax( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildMajor"] = "1",
+                ["BuildMinor"] = "2",
+                ["BuildPatch"] = "3",
+                ["CiBuildIndex"] = "01234ABC",
+                ["CiBuildName"] = "01234_ABC"
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse( buildResults.Success );
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM108").ToList();
+            Assert.AreEqual( 1, errors.Count );
+        }
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ParseBuildVersionXmlTaskErrorTests.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ParseBuildVersionXmlTaskErrorTests.cs
@@ -1,0 +1,133 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ParseBuildVersionXmlTaskErrorTests.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+using Microsoft.Build.Evaluation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    [TestClass]
+    [TestCategory("Error Validation")]
+    public class ParseBuildVersionXmlTaskErrorTests
+    {
+        public ParseBuildVersionXmlTaskErrorTests( TestContext ctx )
+        {
+            ArgumentNullException.ThrowIfNull(ctx);
+            ArgumentException.ThrowIfNullOrWhiteSpace(ctx.TestResultsDirectory);
+
+            Context = ctx;
+        }
+
+        public TestContext Context { get; }
+
+        [TestMethod]
+        public void CSM200_Empty_BuildVersionXml_path_fails( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildVersionXml"] = " " // Non-null/empty, but all WS
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM200").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM201_non_existent_BuildVersionXml_file_fails( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildVersionXml"] = Context.CreateRandomFilePath()
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM201").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM202_existing_BuildVersionXml_file_with_missing_BuildVersionData_element_fails( )
+        {
+            string buildVersionXmlPath = Context.CreateRandomFilePath();
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildVersionXml"] = buildVersionXmlPath
+            };
+
+            using(var strm = File.Open(buildVersionXmlPath, FileMode.CreateNew))
+            {
+                var element = new XElement("RootElement");
+                element.Save( strm );
+                Context.WriteLine( $"BuildVersionXML written to: '{buildVersionXmlPath}'" );
+            }
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM202").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+
+        [TestMethod]
+        public void CSM203_existing_BuildVersionXml_file_with_unknown_attribute_warns( )
+        {
+            string buildVersionXmlPath = Context.CreateRandomFilePath();
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildVersionXml"] = buildVersionXmlPath
+            };
+
+            using(var strm = File.Open(buildVersionXmlPath, FileMode.CreateNew))
+            {
+                var element = new XElement("BuildVersionData",
+                                           new XAttribute("BuildMajor", "1"),
+                                           new XAttribute("BuildMinor", "2"),
+                                           new XAttribute("BuildPatch", "3"),
+                                           new XAttribute("Unknown", "Uh-oh!")
+                                          );
+                element.Save( strm );
+                Context.WriteLine( $"BuildVersionXML written to: '{buildVersionXmlPath}'" );
+            }
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsTrue(buildResults.Success);
+            var warnings = buildResults.Output.WarningEvents.Where(evt=>evt.Code == "CSM203").ToList();
+            Assert.AreEqual(1, warnings.Count);
+        }
+
+        [TestMethod]
+        public void CSM204_existing_BuildVersionXml_file_with_invalid_xml_fails( )
+        {
+            var globalProperties = new Dictionary<string, string>
+            {
+                ["BuildVersionXml"] = Context.CreateRandomFile() // random empty file is NOT valid XML
+            };
+
+            using var collection = new ProjectCollection(globalProperties);
+            using var fullResults = Context.CreateTestProjectAndInvokeTestedPackage("net8.0", collection);
+            var (buildResults, props) = fullResults;
+            Assert.IsFalse(buildResults.Success);
+            var errors = buildResults.Output.ErrorEvents.Where(evt=>evt.Code == "CSM204").ToList();
+            Assert.AreEqual(1, errors.Count);
+        }
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectBuildResults.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectBuildResults.cs
@@ -1,0 +1,34 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ProjectBuildResults.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.Build.Utilities.ProjectCreation;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    [SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "Simple record used here" )]
+    internal readonly ref struct ProjectBuildResults
+    {
+        public ProjectBuildResults( ProjectCreator creator, BuildOutput output, bool success )
+        {
+            Creator = creator;
+            Output = output;
+            Success = success;
+        }
+
+        public readonly ProjectCreator Creator { get; }
+
+        public BuildOutput Output { get; }
+
+        public readonly bool Success { get; }
+
+        public readonly void Dispose( )
+        {
+            Output.Dispose();
+        }
+    }
+}

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectCreatorLibraryExtensions.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectCreatorLibraryExtensions.cs
@@ -52,7 +52,7 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
                                 sdk,
                                 targetFramework,
                                 outputType: null,
-                                customAction,
+                                null,
                                 defaultTargets,
                                 initialTargets,
                                 treatAsLocalProperty,
@@ -63,7 +63,7 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
                                  .Property( "Nullable", "disable" )
                                  .Property( "ManagePackageVersionsCentrally", "false" )
                                  .Property( "ImplicitUsings", "disable" )
-                                 ;
+                                 .CustomAction(customAction);
         }
 
         private static XElement GetOrCreateSourceMappingElement( XElement configuration )

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectInstanceExtensions.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/ProjectInstanceExtensions.cs
@@ -29,11 +29,9 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
 
         // Sadly, project creator library doesn't have support for after build state retrieval...
         // Fortunately, it is fairly easy to create an extension to handle that scenario.
-        public static (BuildResult BuildResult, BuildOutput Output) Build( this ProjectInstance self, params string[] targetsToBuild )
+        public static BuildResult Build( this ProjectInstance self, BuildOutput buildOutput, params string[] targetsToBuild )
         {
-            // !@#$ project creator hides new and uses a dumb wrapper for create. [Sigh...]
-            var buildOutput = BuildOutput.Create();
-            var result = BuildManager.DefaultBuildManager.Build(
+            return BuildManager.DefaultBuildManager.Build(
                                           new BuildParameters() { Loggers = [buildOutput] },
                                           new BuildRequestData(
                                               self,
@@ -42,7 +40,6 @@ namespace Ubiquity.Versioning.Build.Tasks.UT
                                               BuildRequestDataFlags.ProvideProjectStateAfterBuild
                                               )
                                           );
-            return (result, buildOutput);
         }
     }
 }

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/Ubiquity.Versioning.Build.Tasks.UT.csproj
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/Ubiquity.Versioning.Build.Tasks.UT.csproj
@@ -12,6 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Ubiquity.NET.Versioning.Build.Tasks\Ubiquity.NET.Versioning.Build.Tasks.csproj">
+      <ReferenceOutputAssembly>False</ReferenceOutputAssembly>
+      <PrivateAssets>All</PrivateAssets>
+      <Private>False</Private>
+    </ProjectReference>
     <ProjectReference Include="..\Ubiquity.NET.Versioning\Ubiquity.NET.Versioning.csproj" />
   </ItemGroup>
 

--- a/src/Ubiquity.Versioning.Build.Tasks.UT/VersioningProjectBuildResults.cs
+++ b/src/Ubiquity.Versioning.Build.Tasks.UT/VersioningProjectBuildResults.cs
@@ -1,0 +1,35 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="VersioningProjectBuildResults.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// </copyright>
+// -----------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Ubiquity.Versioning.Build.Tasks.UT
+{
+    [SuppressMessage( "StyleCop.CSharp.DocumentationRules", "SA1649:File name should match first type name", Justification = "Simple record used here" )]
+    internal readonly ref struct VersioningProjectBuildResults
+    {
+        public VersioningProjectBuildResults( ProjectBuildResults buildResults, BuildProperties properties )
+        {
+            BuildResults = buildResults;
+            Properties = properties;
+        }
+
+        public ProjectBuildResults BuildResults { get; }
+
+        public BuildProperties Properties { get; }
+
+        public void Deconstruct(out ProjectBuildResults buildResults, out BuildProperties properties)
+        {
+            buildResults = BuildResults;
+            properties = Properties;
+        }
+
+        public void Dispose( )
+        {
+            BuildResults.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Added more testing and updated code based on results
* Task now validates the pre-release number/fix ONLY when a pre-release name is provided.
    - Otherwise the number/fix are irrelevant.
* Adjusted error codes to include the validation of the Fix as it accidentally used the wrong value and therefore, did not have a distinct code.
* Added error code for Missing BuildVersionData element in BuildVersionXml file
    - This resulted in an adjustment of error codes.
* Moved clearing of CI info properties to targets file
    - This is required to have the correct impact as the props file is imported BEFORE any project file. Thus, anything set in a project file would re-set the value to non-empty which isn't the intended state.