### PR TITLE
Restored correct URI for Initialize-BuildEnvironment.

### DIFF
--- a/PsModules/RepoBuild/Public/Initialize-BuildEnvironment.ps1
+++ b/PsModules/RepoBuild/Public/Initialize-BuildEnvironment.ps1
@@ -60,7 +60,7 @@ function Initialize-BuildEnvironment
 
         # Add repo specific values
         $buildInfo['PackagesRoot'] = Join-Path $buildInfo['BuildOutputPath'] 'packages'
-        $buildInfo['OfficialGitRemoteUrl'] = 'https://github.com/UbiquityDotNET/CSemVer.GitBuild'
+        $buildInfo['OfficialGitRemoteUrl'] = 'https://github.com/UbiquityDotNET/CSemVer.GitBuild.git'
 
         # make sure directories required (but not created by build tools) exist
         New-Item -ItemType Directory -Path $buildInfo['BuildOutputPath'] -ErrorAction SilentlyContinue | Out-Null


### PR DESCRIPTION
Restored correct URI for Initialize-BuildEnvironment.
* It is unclear why that was changed to drop the `.git`