### PR TITLE
Updated release build action

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -67,10 +67,17 @@ jobs:
           branch: gh-pages
 
       - name: Publish packages to NuGet.org
-        run: dotnet nuget push .\BuildOutput\NuGet\*.nupkg -k '${{ secrets.NUGETPUSH_ACCESS_TOKEN }}' -s 'https://api.nuget.org/v3/index.json' --skip-duplicate
+        run: |
+          if( [string]::IsNullOrWhiteSpace('${{ secrets.NUGETPUSH_ACCESS_TOKEN }}'))
+          {
+              throw "'NUGETPUSH_ACCESS_TOKEN' does not exist"
+          }
+          dotnet nuget push .\BuildOutput\NuGet\*.nupkg -k ${{ secrets.NUGETPUSH_ACCESS_TOKEN }} -s 'https://api.nuget.org/v3/index.json' --skip-duplicate
 
       - name: Create Release
         if: (!cancelled())
         uses: softprops/action-gh-release@v2
         with:
           draft: true
+          files: BuildOutput/NuGet/*.nupkg
+

--- a/BuildVersion.xml
+++ b/BuildVersion.xml
@@ -6,5 +6,5 @@ This file is updated on a public release to set the next build that pre-releases
     BuildMinor = "0"
     BuildPatch = "0"
     PreReleaseName = "rc"
-    PreReleaseNumber = "1"
+    PreReleaseNumber = "2"
 />


### PR DESCRIPTION
Updated release build action
* Unified with LLvm.Libs where NuGet push worked
    - Sadly I have no idea why it is failing. Running the command locally with the API key works...
* Updated GH release creation to include the NUPKG files so they are available as part of the release.
* Bumped version to next release