### PR TITLE
General refactoring and cleanup

### DIFF
--- a/New-GeneratedVersionProps.ps1
+++ b/New-GeneratedVersionProps.ps1
@@ -342,7 +342,7 @@ try
     $propGroupElement.AppendChild($assemblyVersionElement) | Out-Null
 
     $informationalVersionElement = $xmlDoc.CreateElement('InformationalVersion')
-    $informationalVersionElement.InnerText = $csemVer.ToString($true, $false) # long form of version
+    $informationalVersionElement.InnerText = $csemVer.ToString($true) # (With metadata)
     $propGroupElement.AppendChild($informationalVersionElement) | Out-Null
 
     # inform unit testing of the environment as the env vars are NOT accessible to the tests

--- a/New-GeneratedVersionProps.ps1
+++ b/New-GeneratedVersionProps.ps1
@@ -69,9 +69,6 @@ class PreReleaseVersion
     [ValidateSet('alpha', 'beta', 'delta', 'epsilon', 'gamma', 'kappa', 'prerelease', 'rc')]
     [string] $Name;
 
-    [ValidateSet('a', 'b', 'd', 'e', 'g', 'k', 'p', 'r')]
-    [string] $ShortName;
-
     [ValidateRange(-1,7)]
     [int] $Index;
 
@@ -91,7 +88,6 @@ class PreReleaseVersion
             if($this.Index -ge 0)
             {
                 $this.Name = [PreReleaseVersion]::PreReleaseNames[$this.Index]
-                $this.ShortName = [PreReleaseVersion]::PreReleaseShortNames[$this.Index]
             }
 
             $this.Number = $buildVersionXmlData['PreReleaseNumber'];
@@ -103,15 +99,15 @@ class PreReleaseVersion
         }
     }
 
-    [string] ToString([bool] $useShortForm = $false)
+    [string] ToString()
     {
         $hasPreRel = $this.Index -ge 0
 
         $bldr = [System.Text.StringBuilder]::new()
         if($hasPreRel)
         {
-            $bldr.Append('-').Append($useShortForm ? $this.ShortName : $this.Name)
-            $delimFormat = $useShortForm ? '-{0:D02}' : '.{0}'
+            $bldr.Append('-').Append( $this.Name)
+            $delimFormat = '.{0}'
             if(($this.Number -gt 0))
             {
                 $bldr.AppendFormat($delimFormat, $this.Number)
@@ -126,7 +122,6 @@ class PreReleaseVersion
     }
 
     hidden static [string[]] $PreReleaseNames = @('alpha', 'beta', 'delta', 'epsilon', 'gamma', 'kappa', 'prerelease', 'rc' );
-    hidden static [string[]] $PreReleaseShortNames = @('a', 'b', 'd', 'e', 'g', 'k', 'p', 'r');
 
     hidden static [int] GetPrerelIndex([string] $preRelName)
     {
@@ -138,17 +133,8 @@ class PreReleaseVersion
                          Where-Object {$_['Name'] -ieq $preRelName} |
                          ForEach-Object {$_['Index']} |
                          Select-Object -First 1
-
-            # if not found in long names, test against the short names
-            if($preRelIndex -lt 0)
-            {
-                $preRelIndex = [PreReleaseVersion]::PreReleaseShortNames |
-                             ForEach-Object {$index=0} {@{Name = $_; Index = $index++}} |
-                             Where-Object {$_['Name'] -ieq $preRelName} |
-                             ForEach-Object {$_['Index']} |
-                             Select-Object -First 1
-            }
         }
+
         return $preRelIndex
     }
 
@@ -224,13 +210,13 @@ class CSemVer
         $this.FileVersion = [CSemVer]::ConvertToVersion($fileVer64)
     }
 
-    [string] ToString([bool] $includeMetadata, [bool]$useShortForm)
+    [string] ToString([bool] $includeMetadata)
     {
         $bldr = [System.Text.StringBuilder]::new()
         $bldr.AppendFormat('{0}.{1}.{2}', $this.Major, $this.Minor, $this.Patch)
         if($this.PreReleaseVersion)
         {
-            $bldr.Append($this.PreReleaseVersion.ToString($useShortForm))
+            $bldr.Append($this.PreReleaseVersion.ToString())
         }
 
         $hasPreRel = $this.PreReleaseVersion -and $this.PreReleaseVersion.Index -ge 0
@@ -344,11 +330,11 @@ try
     $propGroupElement.AppendChild($fileVersionElement) | Out-Null
 
     $packageVersionElement = $xmlDoc.CreateElement('PackageVersion')
-    $packageVersionElement.InnerText = $csemVer.ToString($false,$false) # long form of version (No metadata)
+    $packageVersionElement.InnerText = $csemVer.ToString($false) # (No metadata)
     $propGroupElement.AppendChild($packageVersionElement) | Out-Null
 
     $productVersionElement = $xmlDoc.CreateElement('ProductVersion')
-    $productVersionElement.InnerText = $csemVer.ToString($true, $false) # long form of version (With metadata)
+    $productVersionElement.InnerText = $csemVer.ToString($true) # (With metadata)
     $propGroupElement.AppendChild($productVersionElement) | Out-Null
 
     $assemblyVersionElement = $xmlDoc.CreateElement('AssemblyVersion')
@@ -361,7 +347,8 @@ try
 
     # inform unit testing of the environment as the env vars are NOT accessible to the tests
     # Sadly, the `dotnet test` command does not spawn the tests with an inherited environment.
-    # So they cannot know what the scenario is.
+    # So they cannot know what the scenario is unless that information is conveyed by some other
+    # means.
     $buildKindElement = $xmlDoc.CreateElement('BuildKind')
     $buildKindElement.InnerText = $buildKind
     $propGroupElement.AppendChild($buildKindElement) | Out-Null

--- a/docfx/build-tasks/index.md
+++ b/docfx/build-tasks/index.md
@@ -58,8 +58,8 @@ The following is a list of the version formats in descending order of precedence
 | Official PreRelease | `{BuildMajor}.{BuildMinor}.{BuildPatch}-{PreReleaseName}[.PreReleaseNumber][.PreReleaseFix]+{BuildMeta}` |
 | Official Release | `{BuildMajor}.{BuildMinor}.{BuildPatch}+{BuildMeta}` |
 
-That is the, CI BuildName is specifically chosen to ensure the ordering matches the expected
-behavior for a build while making sense for most uses.
+That is the, CI BuildName (`ZZZ`, `PRQ`, `BLD`) is specifically chosen to ensure the ordering
+matches the expected behavior for a build while still making sense for most uses.
 
 This project provides an MSBUILD task to automate the generation of these versions in an easy
 to use NuGet Package.
@@ -80,10 +80,10 @@ guarantees that each build has a different file and assembly version so that str
 signing functions properly to enable loading different versions in the same process.
 
 >[!IMPORTANT]
-> A file version quad representation of a CSemVer does NOT carry with it the CI information nor
-> the build metadata. It only contains a single bit to indicate a Release vs. a CI build. In
-> fact, the official CSemVer specs are silent on the use of this bit though the "playground"
-> does indicate an ODD numbered revision is a CI build.
+> A file version quad representation of a CSemVer does NOT carry with it the CI information
+> nor any build metadata. It only contains a single bit to indicate a Release vs. a CI build.
+> In fact, the official CSemVer specs are silent on the use of this bit though the "playground"
+> does indicate an ODD numbered revision is reserved as a CI build.
 
 The Major, Minor and Patch versions are only updated in the primary branch at the time
 of a release. This ensures the concept that SemVer versions define released products. The
@@ -111,22 +111,26 @@ Unless specified or a release build [$(IsReleaseBuild) is true] this indicates t
 Build index for a build. For a CI build this will default to the ISO-8601 formatted time stamp
 of the build. Consumers can specify any value desired as an override but should ensure the
 value is ALWAYS increasing according to the rules of a CSemVer-CI. Generating duplicates for
-the same build is an error condition and can lead to consumer confusion.
+the same build is an error condition and can lead to consumer confusion. Usually, if set
+externally, this is set to the time stamp of the head commit of a repository so that any
+automated builds are consistent with the build number. (For PullRequest buddy builds this is
+usually left as a build time stamp)
 
 ### CiBuildName
 Unless explicitly provided, the CiBuildName is determined by a set of properties that indicate
 the nature of the build. The properties used (in evaluation order) are:
 
 |Name               |Default Value  |CiBuildName    | Description|
-|-------------------|---------------|---------------|------------|
+|:-----------------:|:-------------:|:-------------:|:-----------|
 |IsPullRequestBuild | `<Undefined>` |`PRQ` if true  | Used to indicate if the build is from a pull request |
 |IsAutomatedBuild   | `<Undefined>` |`BLD` if true  | Used to indicate if the build is an automated build |
 |IsReleaseBuild     | `<Undefined>` |`ZZZ` if !true | Used to indicate if the build is an official release build |
 
-These three values are determined by the automated build in some form. These are either explicit
-variables set for the build definition or determined on the fly based on values set by the build.
-Commonly a `directory.build.props` for a repository will specify these. The following is an
-example for setting them based on an AppVeyor build in the `Directory.Build.props` file:
+These three values are determined by the automated build in some form. These are either
+explicit variables set for the build definition or determined on the fly based on values set by
+the build. Commonly a `directory.build.props` for a repository will specify these. The
+following is an example for setting them based on an AppVeyor build in the
+`Directory.Build.props` file:
 
 ```xml
 <PropertyGroup>
@@ -230,7 +234,7 @@ function Get-CurrentBuildKind
 
 $currentBuildKind = Get-CurrentBuildKind
 
-# set/reset legacy environment vars for non-script tools (i.e. msbuild.exe)
+# set/reset legacy environment vars for non-script tools
 $env:IsAutomatedBuild = $currentBuildKind -ne [BuildKind]::LocalBuild
 $env:IsPullRequestBuild = $currentBuildKind -eq [BuildKind]::PullRequestBuild
 $env:IsReleaseBuild = $currentBuildKind -eq [BuildKind]::ReleaseBuild

--- a/docfx/build-tasks/toc.yml
+++ b/docfx/build-tasks/toc.yml
@@ -1,3 +1,3 @@
-# TOC (Left nav) for LLVM folder
+# TOC (Left nav) this folder
 - name: Overview
   href: index.md

--- a/docfx/docfx.json
+++ b/docfx/docfx.json
@@ -74,10 +74,11 @@
         "fileMetadataFiles": [],
         "postProcessors": [],
         "globalMetadata": {
-            "_appTitle": "Ubiquity.NET",
+            "_appTitle": "Ubiquity.NET.Versioning",
             "_appFooter": "Copyright (C) 2017-2025, Ubiquity.NET Contributors",
             "_appLogoPath": "favicon-32x32.png",
             "_disableBreadcrumb": true,
+            "_enableNewTab": true,
             "_gitContribute": {
                 "repo": "https://github.com/UbiquityDotNET/CSemVer.GitBuild",
                 "branch": "develop"

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -15,10 +15,10 @@ while conforming to the syntax of CSemVer and CSemVer-CI
 > There is confusion on the ordering of a CI build with relation to a release build with
 > CSemVer. A CI Build is either an initial build of an unreleased version with
 > [Major.Minor.Patch] == [0.0.0]. Or, it is based on the previously released version and is
-> [Major.Minor.Patch+1]. That is, a CI build is ordered BEFORE all other release builds, or it
-> is ordered AFTER, and is based on, a release build! In particular a CI build version does NOT
-> indicate what it will become when it is finally released, but what release it was based on
-> (If any).
+> [Major.Minor.Patch+1]. That is, a CI build is ordered BEFORE all release builds, or it
+> is ordered AFTER a specific release it is based on! In particular a CI build version does
+> ***NOT*** indicate what it will become when it is finally released, but what release it was
+> based on (If any).
 
 ---
 [Attributions](Attributions.md)

--- a/docfx/templates/Ubiquity/public/main.css
+++ b/docfx/templates/Ubiquity/public/main.css
@@ -1,8 +1,9 @@
 @charset "UTF-8";
 
 /*
-Disable display of inherited members. It would be nice if there was a build option to not even generate this noise,
-but sadly, there is none so this disables the final render of such things.
+Disable display of inherited members. It would be nice if there was a build option
+to not even generate this noise, but sadly, there is none so this disables the
+final render of such things.
 */
 .typelist.inheritedMembers {
     display: none

--- a/docfx/templates/Ubiquity/readme.md
+++ b/docfx/templates/Ubiquity/readme.md
@@ -1,5 +1,9 @@
 # Ubiquity DOCFX template
+>[!NOTE]
+> This markdown file is NOT included in the formal docs output. It is used to document
+> the input to the process of creating the formal documentation.
+
 This template adds support to the modern template to disable some features like inherited
 members. It would be nice if docfx didn't even generate such things, but it has no knobs to
 control that so it can only be disabled by a custom CSS to hide the content at page render
-time on the client...
+time on the client after it is generated and downloaded. :unamused:

--- a/docfx/versioning-lib/index.md
+++ b/docfx/versioning-lib/index.md
@@ -1,8 +1,12 @@
 # About
-The Ubiquity.NET.Versioning library provides types to support use of a Constrained Semantic
-Version ([CSemVer](https://csemver.org/)) in a build. It is viable as a standalone package to allow
-validation of or comparisons to versions reported at runtime. (Especially from native interop that
-does not support NuGet package dependencies or versioning at runtime.)
+The Ubiquity.NET.Versioning library provides types to support use of versioning via
+1) [Semantic Versioning](https://semver.org)
+2) [Constrained Semantic Versioning](https://csemver.org)
+    - Including Continuous Integration (CI) via CSemVer-CI
+
+It is viable as a standalone package to allow validation of or comparisons to versions reported
+at runtime. (Especially from native interop that does not support package dependencies or
+versioning at runtime.)
 
 ## Example
 ``` C#
@@ -18,5 +22,29 @@ if (actual < expectedMinimum)
 ```
 
 ## Formatting
-The library also contains support for proper formatting of strings based on the rules
-of a CSemVer
+The library contains support for proper formatting of strings based on the rules
+of a SemVer, CSemVer, and CSemVer-CI
+
+## Parsing
+The library contains support for parsing of strings based on the rules of a
+SemVer, CSemVer, and CSemVer-CI
+
+## Ordering
+The types all support `IComparable<T>`<sup>[1](#footnote_1)</sup> and properly handle correct sort ordering of the
+versions according to the rules of SemVer (Which, CSemVer and CSemVer-CI follow)
+
+>[!WARNING]
+> The formal 'spec' for [CSemVer](https://csemver.org) remains mostly silent on the point of
+> the short format. See this [known issue](https://github.com/CK-Build/csemver.org/issues/2).
+> Since, the existence of that form was to support NuGet V2, which is now obsolete, this
+> library does not support the short form at all. (This choice keeps documentation clarity
+> [NOT SUPPORTED] and implementation simplicity)
+
+------
+<sup><a id="footnote_1">1</a></sup> The `SemVer` class does NOT support `IComparable<T>` as
+the spec is not explicit on case sensitive comparison of AlphaNumeric Identifiers.
+Unfortunately, major repositories using SemVer have chosen to use different comparisons. Thus,
+a consumer is required to know a-priori if the version is compared insensitive or not.
+`IComparer<SemVer>` instances are available for both cases via the static class
+`SemVerComparer`.
+

--- a/docfx/versioning-lib/namespaces/Ubiquit.NET.Versioning.md
+++ b/docfx/versioning-lib/namespaces/Ubiquit.NET.Versioning.md
@@ -54,35 +54,40 @@ classDiagram
     CSemVer "0..1" *-- PreReleaseVersion:PreReleaseVersion
     CSemVerCI "1" *-- CSemVer:BaseVersion
 ```
+>[!IMPORTANT]
+> There is no inheritance between a `SemVer`, `CSemVer`, and `CSemVerCI`. While conversion does
+> exist they are not completely compatible due the constraints of ALWAYS comparing case
+> insensitive for `CSemVer` and `CSemVerCI`
 
 The primary differences between a generic SemVer, a CSemVer and CSemVerCI is in how the
 sequence of pre-release versioning components is handled and the constraints placed on the
 Major, Minor and Patch version numbers.
 
-A SemVer technically has no constraints on the range of the integral components and thus
-a `BigInteger` is used. Though, in practical terms, if any of the components exceeds the size
-of `UInt64` there's probably something wrong with how the thing the version applies to is
-versioned :confused:.
+>[!NOTE]
+> A SemVer technically has no constraints on the range of the integral components and thus
+> a `BigInteger` is used. Though, in practical terms, if any of the components exceeds the
+> size of `UInt64` there's probably something wrong with how the thing the version applies
+> to is versioned :confused:. More realistically, CSemVer[-CI] constrains the integral
+> components to specific ranges to allow conversion to an ordered version and `FileVersionQuad`.
 
-More realistically, CSemVer[-CI] constrains the integral components to specific ranges to allow
-conversion to an ordered version and FileVersionQuad. Additionally, a CSemVer[-CI] ALWAYS
-orders versions using a case-insensitive comparison for AlphaNumeric Identifiers in the version.
-Sadly, the SemVer spec is silent on the point and various major implementations for popular
-frameworks have chosen different approaches. Thus a consumer of a pure SemVer needs to know
-which kind of comparison to use in order to get correct results.
 
 >[!IMPORTANT]
-> Due to this ambiguity, it is recommended that all uses of SemVer in the real world use ALL
-> the same case (All *UPPER* or all *lower*). This avoids the confusion and produces correct
-> ordering no matter what variant of comparison a consumer uses. Problems come when the version
-> uses a *Mixed* case format.
+> A CSemVer[-CI] is ***ALWAYS*** ordered using a case-insensitive comparison for AlphaNumeric
+> Identifiers in the version. Sadly, the SemVer spec is not explicit on the point of case
+> sensitivity and various major implementations for popular frameworks have chosen different
+> approaches. Thus a consumer of a pure SemVer needs to know which kind of comparison to use
+> in order to get correct results.
+> Due to the ambiguity of case sensitivity in ordering, it is recommended that all uses of
+> SemVer in the real world use ALL the same case (All *UPPER* or all *lower*). This avoids
+> the confusion and produces correct ordering no matter what variant of comparison a consumer
+> uses. Problems come when the version uses a *Mixed* case format.
 
 ### CSemVer Constraints on the integral components
 In particular the values are constrained
 as follows:
 
 | Name | Range |
-|------|-------|
+|:----:|:-----:|
 | Major | [0-99999] |
 | Minor | [0-49999] |
 | Patch | [0-9999] |
@@ -97,14 +102,31 @@ following table:
 | Index | Name | Description |
 |:-----:|:----:|:------------|
 | 0     | Name<sup>[1](#footnote_1)</sup> | Name of the pre-release (one of a fixed set of 8 names) |
-| 1     | Number  | pre-release number for a build |
-| 2     | Number  | pre-release fix for a build |
+| 1     | Number | pre-release number for a build |
+| 2     | Fix  | pre-release fix for a build |
+
+### CSemVer[CI] Pre-release names
+The names of a pre-release are constrained in CSemVer[-CI] to the following:<sup>[1](#footnote_1)</sup>
+
+|Name     | Index |
+|:-------:|:-----:|
+| alpha   | 0 |
+| beta    | 1 |
+| delta   | 2 |
+| epsilon | 3 |
+| gamma   | 4 |
+| kappa   | 5 |
+| pre<sup>[2](#footnote_2)</sup>| 6
+| rc | 7 |
 
 ------
-<sup><a id="footnote_1">1</a></sup> The exact string representation of the short form of a CSemVer as specified is not
+<sup><a id="footnote_1">1</a></sup> This library does NOT support the short form of names in a
+CSemVer. The exact string representation of the short form of a CSemVer as specified is not
 entirely clear. (see:[this issue](https://github.com/CK-Build/csemver.org/issues/2)) This
-implementation has chosen to ignore the short form completely. Based on what little is said about
-it int the spec, it was created to support a limitation in NuGet v2, which is now obsolete.
-Thus, the libraries do not support producing strings using the short form, nor do they
-recognize one when parsing. 
+implementation has chosen to ignore the short form completely. Based on what little is said
+about it int the spec, it was created to support a limitation in NuGet v2, which is now
+obsolete. Thus, the libraries do not support producing strings using the short form, nor do
+they recognize one when parsing. 
 
+<sup><a id="footnote_2">2</a></sup> `prerelease` is always considered valid as well. Internally
+it is automatically converted to the shorter `pre` form.

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
@@ -48,7 +48,7 @@ namespace Ubiquity.NET.Versioning.UT
         {
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             // VALIDATING behavior of API is the point of this test.
-            var argnex = Assert.ThrowsExactly<ArgumentNullException>(()=>_=new CSemVerCI((string?)null, "c-name", null));
+            var argnex = Assert.ThrowsExactly<ArgumentNullException>(()=>_=new CSemVerCI(null, "c-name", null));
             Assert.AreEqual("index", argnex.ParamName, "null parameter should throw"); // sadly there is no refactoring safe nameof() expression for a parameter at the call site...
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
@@ -149,8 +149,6 @@ namespace Ubiquity.NET.Versioning.UT
             var ver_name_1_same = new CSemVerCI( new CSemVer( 20, 1, 4 ), "BuildIndex01", "BuildName01" );
             var ver_name_2 = new CSemVerCI( new CSemVer( 20, 1, 4 ), "BuildIndex01", "BuildName02" );
 
-            Assert.IsTrue(ver_name_1.CompareTo(null) > 0, "Any instance should compare greater than null");
-
             Assert.IsTrue(ver_name_1.CompareTo(ver_name_2) < 0);
             Assert.IsTrue(ver_name_2.CompareTo(ver_name_1) > 0);
 
@@ -166,7 +164,6 @@ namespace Ubiquity.NET.Versioning.UT
             var ver_name_1 = new CSemVerCI( new CSemVer( 20, 1, 4, null, [ "buildMeta" ] ), "BuildIndex01", "BuildName01" );
             var ver_name_1_same = new CSemVerCI( new CSemVer( 20, 1, 4, null, [ "buildMeta" ] ), "BuildIndex01", "BuildName01" );
             var ver_name_2 = new CSemVerCI( new CSemVer( 20, 1, 4, null, [ "buildMeta" ] ), "BuildIndex01", "BuildName02" );
-            Assert.IsTrue(ver_name_1.CompareTo(null) > 0, "Any instance should compare greater than null");
 
             Assert.IsTrue(ver_name_1.CompareTo(ver_name_2) < 0);
             Assert.IsTrue(ver_name_2.CompareTo(ver_name_1) > 0);
@@ -184,7 +181,6 @@ namespace Ubiquity.NET.Versioning.UT
             var ver_name_1 = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1 ), "BuildIndex01", "BuildName01" );
             var ver_name_1_same = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1 ), "BuildIndex01", "BuildName01" );
             var ver_name_2 = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1 ), "BuildIndex01", "BuildName02" );
-            Assert.IsTrue(ver_name_1.CompareTo(null) > 0, "Any instance should compare greater than null");
 
             Assert.IsTrue(ver_name_1.CompareTo(ver_name_2) < 0);
             Assert.IsTrue(ver_name_2.CompareTo(ver_name_1) > 0);
@@ -204,7 +200,6 @@ namespace Ubiquity.NET.Versioning.UT
             var ver_name_1 = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1, ["BuildMeta"] ), "BuildIndex01", "BuildName01" );
             var ver_name_1_same = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1, ["BuildMeta", "MoreMeta"] ), "BuildIndex01", "BuildName01" );
             var ver_name_2 = new CSemVerCI( new CSemVer( 1, 2, 3, alpha_0_1, ["SomeOhterMeta"] ), "BuildIndex01", "BuildName02" );
-            Assert.IsTrue(ver_name_1.CompareTo(null) > 0, "Any instance should compare greater than null");
 
             Assert.IsTrue(ver_name_1.CompareTo(ver_name_2) < 0);
             Assert.IsTrue(ver_name_2.CompareTo(ver_name_1) > 0);

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerTests.cs
@@ -41,7 +41,7 @@ namespace Ubiquity.NET.Versioning.UT
         [TestMethod]
         public void DefaultConstructorTests( )
         {
-            var ver = new CSemVer();
+            var ver = default( CSemVer );
             Assert.AreEqual( 0, ver.Major );
             Assert.AreEqual( 0, ver.Minor );
             Assert.AreEqual( 0, ver.Patch );

--- a/src/Ubiquity.NET.Versioning/AppContextSwitches.cs
+++ b/src/Ubiquity.NET.Versioning/AppContextSwitches.cs
@@ -31,10 +31,10 @@ namespace Ubiquity.NET.Versioning
     /// <note>
     /// Once published in a non-preview release, the name of a switch CANNOT change. It may become inert, but
     /// is NEVER re-purposed to a different meaning or even changed to correct a mis-spelling. Such a correction
-    /// would ADD a new (correctly spelled) name and the adjust the implementation to treat them identically. The
-    /// published name and it's associated behavior is immutable. Whether it does anything or not depends on the version,
-    /// but the behavior itself may never be re-defined. That is, it always either does what it was documented to do in the
-    /// first release available, or it does nothing. It NEVER does something else.
+    /// would ADD a new (correctly spelled) name and then adjust the implementation to treat the old and new forms
+    /// identically. The published name and it's associated behavior is immutable. Whether it does anything or not
+    /// depends on the version, but the behavior itself may never be re-defined. That is, it always either does what
+    /// it was documented to do in the first release available, or it does nothing. It ***NEVER*** does something else.
     /// </note>
     /// </remarks>
     /// <seealso href="https://csemver.org/"/>
@@ -42,7 +42,7 @@ namespace Ubiquity.NET.Versioning
     {
         /// <summary>Name of the switch that controls the <see cref="CSemVerCIOnlySupportsBuildMetaOnZeroTimedVersions"/> property</summary>
         public const string CSemVerCIOnlySupportsBuildMetaOnZeroTimedVersionsName
-            = "Ubiquity.NET.Versioning.AppContextSwitches.CSemVerCIOnlySupportsBuildMetaOnZeroTimedVersions"; //<== DO NOT change name (even when refactoring!)
+            = "Ubiquity.NET.Versioning.AppContextSwitches.CSemVerCIOnlySupportsBuildMetaOnZeroTimedVersions";
 
         /// <summary>Gets or sets a value indicating whether the <see cref="CSemVerCIOnlySupportsBuildMetaOnZeroTimedVersionsName"/> switch is enabled or not</summary>
         /// <remarks>

--- a/src/Ubiquity.NET.Versioning/CSemVer.cs
+++ b/src/Ubiquity.NET.Versioning/CSemVer.cs
@@ -19,19 +19,13 @@ namespace Ubiquity.NET.Versioning
     /// <summary>Holds a Constrained Semantic Version (CSemVer) value</summary>
     /// <remarks>Based on CSemVer v1.0.0-rc.1</remarks>
     /// <seealso href="https://csemver.org/"/>
-    public sealed class CSemVer
+    public readonly struct CSemVer
         : IParsable<CSemVer>
         , IComparable<CSemVer>
         , IComparisonOperators<CSemVer, CSemVer, bool>
         , IEquatable<CSemVer>
     {
-        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> class.</summary>
-        public CSemVer( )
-            : this( 0, 0, 0 )
-        {
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="CSemVer"/> struct.</summary>
         /// <param name="major">Major version value [0-99999]</param>
         /// <param name="minor">Minor version value [0-49999]</param>
         /// <param name="patch">Patch version value [0-9999]</param>
@@ -61,13 +55,13 @@ namespace Ubiquity.NET.Versioning
         }
 
         /// <summary>Gets the Major portion of the core version</summary>
-        public int Major => unchecked((int)ConstrainedVersion.Major); // explicitly unchecked as constructor guarantees success
+        public int Major => unchecked((int)(ConstrainedVersion?.Major ?? 0)); // explicitly unchecked as constructor guarantees success
 
         /// <summary>Gets the Minor portion of the core version</summary>
-        public int Minor => unchecked((int)ConstrainedVersion.Minor);
+        public int Minor => unchecked((int)(ConstrainedVersion?.Minor ?? 0));
 
         /// <summary>Gets the Patch portion of the core version</summary>
-        public int Patch => unchecked((int)ConstrainedVersion.Patch);
+        public int Patch => unchecked((int)(ConstrainedVersion?.Patch ?? 0));
 
         /// <summary>Gets the Pre-Release version value (if any)</summary>
         public PrereleaseVersion? PrereleaseVersion { get; }
@@ -78,7 +72,7 @@ namespace Ubiquity.NET.Versioning
         /// (including leading or all '0'). This collection contains only the identifiers
         /// (no prefix or delimiters).
         /// </remarks>
-        public ImmutableArray<string> BuildMeta => ConstrainedVersion.BuildMeta;
+        public ImmutableArray<string> BuildMeta => ConstrainedVersion?.BuildMeta ?? [];
 
         /// <summary>Gets the <see cref="FileVersionQuad"/> representation of this <see cref="CSemVer"/></summary>
         /// <remarks>
@@ -128,7 +122,7 @@ namespace Ubiquity.NET.Versioning
         /// <inheritdoc/>
         public override string ToString( )
         {
-            return ConstrainedVersion.ToString();
+            return ConstrainedVersion?.ToString() ?? string.Empty;
         }
 
         /// <inheritdoc/>
@@ -137,40 +131,29 @@ namespace Ubiquity.NET.Versioning
         /// that it is EXPLICITLY using case insensitive comparison for the AlphaNumeric
         /// identifiers in a pre-release list.
         /// </remarks>
-        public int CompareTo( CSemVer? other )
+        public int CompareTo( CSemVer other )
         {
-            if(ReferenceEquals(this, other))
-            {
-                return 0;
-            }
-
-            if(other is null)
-            {
-                return 1;
-            }
-
             // CSemVer always uses case insensitive comparisons, but otherwise follows the
             // ordering rules of SemVer.
             return SemVerComparer.SemVer.Compare(ConstrainedVersion, other.ConstrainedVersion);
         }
 
         /// <inheritdoc/>
-        public bool Equals( CSemVer? other )
+        public bool Equals( CSemVer other )
         {
-            return ReferenceEquals(this, other)
-                || (other is not null && SemVerComparer.SemVer.Compare(ConstrainedVersion, other.ConstrainedVersion) == 0);
+            return CompareTo( other ) == 0;
         }
 
         /// <inheritdoc/>
         public override bool Equals( object? obj )
         {
-            return Equals(obj as CSemVer);
+            return obj is CSemVer v && Equals(v);
         }
 
         /// <inheritdoc/>
         public override int GetHashCode( )
         {
-            return ConstrainedVersion.GetHashCode();
+            return ConstrainedVersion?.GetHashCode() ?? 0;
         }
 
         /// <inheritdoc/>
@@ -186,12 +169,12 @@ namespace Ubiquity.NET.Versioning
         public static bool operator <=( CSemVer left, CSemVer right ) => left.CompareTo(right) <= 0;
 
         /// <inheritdoc/>
-        public static bool operator ==( CSemVer? left, CSemVer? right ) => Equals(left, right);
+        public static bool operator ==( CSemVer left, CSemVer right ) => Equals(left, right);
 
         /// <inheritdoc/>
-        public static bool operator !=( CSemVer? left, CSemVer? right ) => !Equals(left, right);
+        public static bool operator !=( CSemVer left, CSemVer right ) => !Equals(left, right);
 
-        private readonly SemVer ConstrainedVersion;
+        private readonly SemVer? ConstrainedVersion;
 
         /// <summary>Tries to parse a <see cref="SemVer"/> as a <see cref="CSemVer"/></summary>
         /// <param name="ver">Version to convert</param>
@@ -356,7 +339,7 @@ namespace Ubiquity.NET.Versioning
         /// <inheritdoc/>
         public static CSemVer Parse( string s, IFormatProvider? provider )
         {
-            return TryParse(s, out CSemVer? retVal, out Exception? ex) ? retVal : throw ex;
+            return TryParse(s, out CSemVer retVal, out Exception? ex) ? retVal : throw ex;
         }
 
         /// <inheritdoc/>

--- a/src/Ubiquity.NET.Versioning/FileVersionQuad.cs
+++ b/src/Ubiquity.NET.Versioning/FileVersionQuad.cs
@@ -31,7 +31,7 @@ namespace Ubiquity.NET.Versioning
     ///     <item><term>bits 48-63</term><description> Major part of Build number</description></item>
     ///     <item><term>bits 32-47</term><description> Minor part of Build number</description></item>
     ///     <item><term>bits 16-31</term><description> Build part of Build number</description></item>
-    ///     <item><term>bits 0-15</term><description> Revision part of Build number (LSB == 0 indicates a CI build; LSB == 1 indicates a release build)</description></item>
+    ///     <item><term>bits 0-15</term><description> Revision part of Build number (LSB indicates a release/CI build see remarks section for details)</description></item>
     /// </list>
     /// </para>
     /// <note type="important">

--- a/src/Ubiquity.NET.Versioning/ParseResultExtensions.cs
+++ b/src/Ubiquity.NET.Versioning/ParseResultExtensions.cs
@@ -14,9 +14,9 @@ namespace Ubiquity.NET.Versioning
 {
     internal static class ParseResultExtensions
     {
-        internal static void ThrowIfFailed<T>([NotNull] this IResult<T> result)
+        internal static void ThrowIfFailed<T>([NotNull] this IResult<T> result, [CallerArgumentExpression(nameof(result))] string? exp = null)
         {
-            if(result.Failed(out Exception? ex))
+            if(result.Failed(out Exception? ex, exp))
             {
                 throw ex;
             }

--- a/src/Ubiquity.NET.Versioning/SemVer.cs
+++ b/src/Ubiquity.NET.Versioning/SemVer.cs
@@ -26,22 +26,20 @@ namespace Ubiquity.NET.Versioning
     /// <para>In practical terms any such component will likely "down convert" to an integer. If a
     /// version component in the real world exceeds the size of an integer, then there is probably
     /// something wrong with how the versioning is maintained.</para>
-    /// <para>This type is intentionally NOT a value type or `record struct` etc... as the ONLY
+    /// <note type="important">
+    /// <para>This type is ***intentionally*** NOT a value type or `record struct` etc... as the ONLY
     /// valid comparison that is always correct is reference equality. Any other comparison/ordering
     /// requires a specific comparer that not only understands the rules of a Semantic Version, but
     /// also deals with case sensitivity of those comparisons. Sadly, the SemVer spec is silent on
     /// the point of case comparisons and different major component repositories have chosen different
     /// interpretations of the spec as a result. Thus any consumer must explicitly decide which comparison
     /// to use.</para>
-    /// <note type="note">
-    /// Technically, the SemVer spec states that alphanumeric Identifiers are ordered lexicographically,
+    /// <para>Technically, the SemVer spec states that alphanumeric Identifiers are ordered lexicographically,
     /// which would make them case sensitive. However, since MAJOR framework repositories have chosen
-    /// to use each approach the real world of ambiguity, sadly, wins.
+    /// to use each approach the real world of ambiguity, sadly, wins.</para>
     /// </note>
     /// </remarks>
     /// <seealso href="https://semver.org/"/>
-    /// <seealso cref="SemVerComparer.CaseSensitive.SemVer"/>
-    /// <seealso cref="SemVerComparer.SemVer"/>
     public sealed class SemVer
         : IParsable<SemVer>
     {
@@ -122,24 +120,6 @@ namespace Ubiquity.NET.Versioning
             }
 
             return bldr.ToString();
-        }
-
-        /// <summary>Gets a comparer for a <see cref="SemVer"/> value</summary>
-        /// <param name="caseSensitive">Indicates if comparisons are case sensitive or not</param>
-        /// <returns>Comparer for <see cref="SemVer"/></returns>
-        /// <remarks>
-        /// Ordering of semantic versions is complicated by the fact that the spec does NOT
-        /// mention case sensitivity for comparing AlphaNumeric IDs. Worse, multiple real world
-        /// implementations adopted policies based on assumptions of sensitivity. Originally, these
-        /// were OS platform specific and not a general problem. However, as cross platform runtimes
-        /// is now common the issue is a serious one as incorrect handling can lead to surprising
-        /// results. <see cref="CSemVer"/> and <see cref="CSemVerCI"/> are explicit in the spec and
-        /// always use case insensitive comparison. But <see cref="SemVer"/> is ambiguous. Thus, calling
-        /// code MUST explicitly declare which it intends to use.
-        /// </remarks>
-        public static IComparer<SemVer> GetComparer(bool caseSensitive/* = false; No default value BY DESIGN - callers must be explicit on intent*/)
-        {
-            return caseSensitive ? SemVerComparer.CaseSensitive.SemVer : SemVerComparer.SemVer;
         }
 
         #region Parsing

--- a/src/Ubiquity.NET.Versioning/SemVerGrammar.cs
+++ b/src/Ubiquity.NET.Versioning/SemVerGrammar.cs
@@ -43,7 +43,7 @@ namespace Ubiquity.NET.Versioning
 
         private static Parser<char> IdentifierChar => Digit.Or( NonDigit ).Named("<identifier character>");
 
-        private static Parser<string> IdentifierChars => IdentifierChar.AtLeastOnce().Named("<Identifier characters>").Text();
+        internal static Parser<string> IdentifierChars => IdentifierChar.AtLeastOnce().Named("<Identifier characters>").Text();
 
         private static Parser<string> Digits => Digit.AtLeastOnce().Named("<digits>").Text();
 
@@ -69,9 +69,9 @@ namespace Ubiquity.NET.Versioning
                .Named("<numeric identifier>")
                .Text();
 
-        public static Parser<string> PreReleaseIdentifier => AlphaNumericIdentifier.Or( NumericIdentifier ).Named("<prerelease-identifier");
+        internal static Parser<string> PreReleaseIdentifier => AlphaNumericIdentifier.Or( NumericIdentifier ).Named("<prerelease-identifier");
 
-        public static Parser<string> BuildIdentifier => AlphaNumericIdentifier.Or(Digits).Named("<build-identifier");
+        internal static Parser<string> BuildIdentifier => AlphaNumericIdentifier.Or(Digits).Named("<build-identifier");
 
         // Formally, SemVer has no limits on a "numeric identifier" so use a BigInteger
         // and worry about down conversion in consumers
@@ -107,7 +107,7 @@ namespace Ubiquity.NET.Versioning
                from patch in IntegralValue.Named("<patch>")
                select new SemVer( major, minor, patch );
 
-        public static Parser<SemVer> SemanticVersion
+        internal static Parser<SemVer> SemanticVersion
             => ( from vc in VersionCore.Named("<version core>")
                  from preRel in PreReleaseData.Named("<pre-release>").XOptional()
                  from build in BuildMetaData.Named("<build>").XOptional()

--- a/src/Ubiquity.NET.Versioning/ValidateArg.cs
+++ b/src/Ubiquity.NET.Versioning/ValidateArg.cs
@@ -9,6 +9,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
+using Sprache;
+
 namespace Ubiquity.NET.Versioning
 {
     // TODO: With C#14 extensions it should be possible to make these a static method extension to the exception types
@@ -22,6 +24,15 @@ namespace Ubiquity.NET.Versioning
         {
             self.ThrowIfNull( exp );
             return regex.IsMatch( self ) ? self : throw new ArgumentException( $"Input '{self}' does not match expected pattern '{regex}'", exp );
+        }
+
+        public static string ThrowIfNotMatch<T>( [NotNull] this string self, Parser<T> parser, [CallerArgumentExpression( nameof( self ) )] string? exp = null )
+        {
+            self.ThrowIfNull( exp ); // whitespace or empty allowed here, but parser may reject it.
+            var parseResult = parser.TryParse(self);
+            return !parseResult.Failed(out Exception? ex, exp)
+                   ? self
+                   : throw new ArgumentException(ex.Message, exp, ex);
         }
 
         public static bool IsOutOfRange<T>( [NotNullWhen(false)] this T? self, T min, T max )


### PR DESCRIPTION
General refactoring and cleanup
* Removed short name support from scripted builds
* Updated/clarified docs
* `CSemVer` and `CSemVerCI` are now value types.
    - SemVer itself is NOT to avoid the problems of exceptions in equality checks or forcing a default comparison for value equality...
* Removed RegEx from `CSemVerCI` in preference to existing Sprache grammar support.
* Removed SemVer.GetComparer as it was redundant and confusing. The static `SemVerComparer` class is usable directly.