### PR TITLE
Update NuGet push action

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -68,11 +68,11 @@ jobs:
 
       - name: Publish packages to NuGet.org
         run: |
-          if( [string]::IsNullOrWhiteSpace('${{ secrets.NUGETPUSH_ACCESS_TOKEN }}'))
+          if( [string]::IsNullOrWhiteSpace('${{secrets.NUGETPUSH_ACCESS_TOKEN}}'))
           {
-              throw "'NUGETPUSH_ACCESS_TOKEN' does not exist"
+              throw "'NUGETPUSH_ACCESS_TOKEN' does not exist, is empty or all whitespace!"
           }
-          dotnet nuget push .\BuildOutput\NuGet\*.nupkg -k ${{ secrets.NUGETPUSH_ACCESS_TOKEN }} -s 'https://api.nuget.org/v3/index.json' --skip-duplicate
+          dotnet nuget push .\BuildOutput\NuGet\*.nupkg --api-key '${{secrets.NUGETPUSH_ACCESS_TOKEN}}' --source 'https://api.nuget.org/v3/index.json' --skip-duplicate
 
       - name: Create Release
         if: (!cancelled())

--- a/docfx/documentation.msbuildproj
+++ b/docfx/documentation.msbuildproj
@@ -1,7 +1,14 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <!--
+    Workaround annoying recurring bug: (IDE, MSBUILD, NoTargets?) Force x86 to AnyCPU.
+    Bug is that anything cares or sets a default that the IDE can't set causing it to occur.
+    -->
+    <Platform Condition="'$(Platform)'=='x86'">AnyCPU</Platform>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'" />
   <!--
   This projects serves as a convenient placeholder to reference the doc files. It uses project relative include
   and exclude patterns to simplify referencing ALL files but skipping over the generated API files.

--- a/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
+++ b/src/Ubiquity.NET.Versioning.UT/CSemVerCITests.cs
@@ -99,9 +99,13 @@ namespace Ubiquity.NET.Versioning.UT
         [TestMethod]
         [TestCategory("Constructor")]
         [TestCategory("AppContext Switch")]
+        [DoNotParallelize]
         public void CSemVerCI_with_BuildMeta_and_switch_enabled_throws( )
         {
             // Temporarily enable the switch to validate behavior
+            // This is an assembly/process wide change so the test is marked with "DoNotParallelizeAttribute" to
+            // ensure that it is NOT run in parallel with any other tests even if the assembly default is changed
+            // to allow such a thing.
             Assert.IsFalse(AppContextSwitches.CSemVerCIOnlySupportsBuildMetaOnZeroTimedVersions, "Default switch state should be OFF");
             using(var x = AutoRestoreAppContextSwitch.Configure(AppContextSwitches.CSemVerCIOnlySupportsBuildMetaOnZeroTimedVersionsName, true))
             {

--- a/src/Ubiquity.NET.Versioning.slnx
+++ b/src/Ubiquity.NET.Versioning.slnx
@@ -37,7 +37,10 @@
     <File Path="../OneFlow/ReadMe.md" />
     <File Path="../OneFlow/Start-Release.ps1" />
   </Folder>
-  <Project Path="../docfx/documentation.msbuildproj" Type="13b669be-bb05-4ddf-9536-439f39a36129" />
+  <Project Path="../docfx/documentation.msbuildproj" Type="13b669be-bb05-4ddf-9536-439f39a36129">
+    <Platform Solution="Release|*" Project="AnyCPU" />
+    <Platform Solution="Debug|*" Project="AnyCPU" />
+  </Project>
   <Project Path="../PsModules/CommonBuild/CommonBuild.pssproj" Type="f5034706-568f-408a-b7b3-4d38c6db8a32" Id="6cafc0c6-a428-4d30-a9f9-700e829fea51" />
   <Project Path="../PsModules/RepoBuild/RepoBuild.pssproj" Type="f5034706-568f-408a-b7b3-4d38c6db8a32" Id="0c6a5f49-fc2a-4e62-8dd8-b31ade60ec76" />
   <Project Path="Ubiquity.NET.Versioning.Build.Tasks.UT/Ubiquity.NET.Versioning.Build.Tasks.UT.csproj" />


### PR DESCRIPTION
Update NuGet push action
* In an attempt to get automated release builds to correctly push the resulting NUGET packages directly the GH actions was updated.
    - The application of the organizational key was quoted and spacing removed
    - The switches use the longer though more readable `--` form to avoid any confusion or overlap with GH options or shell options as they are command specific.
* Updated CI test for AppContext switch to leverage attribute to block parallel test runs.
    - This is mostly a safety measure at this point as the default is to run tests in serial.
* Forced docs project to AnyCPU to help prevent recurring bug where IDE complains about invalid configuration.