### PR TITLE
Fixed release build script

### DIFF
--- a/OneFlow/Publish-Release.ps1
+++ b/OneFlow/Publish-Release.ps1
@@ -31,7 +31,7 @@ $forkRemoteName = Get-GitRemoteName $buildInfo fork
 $releaseBranch = "release/$tagName"
 $officialReleaseBranch = "$officialRemoteName/$releaseBranch"
 
-$mainBranchName = "master"
+$mainBranchName = "main"
 $officialMainBranch = "$officialRemoteName/$mainBranchName"
 
 $mergeBackBranchName = "merge-back-$tagName"


### PR DESCRIPTION
Fixed release build script
* Now uses current name `main` for branch that tracks releases.
    - `master` is now removed and not used.