### PR TITLE
Updated automated build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,6 +14,8 @@ on:
       - '**.md'
       - '**.dic'
       - 'BuildVersion.xml'
+      - 'GitHub/workflows/release-build.yml'
+      - 'OneFlow/**.ps1'
 
   pull_request:
     branches:
@@ -23,6 +25,8 @@ on:
       - '**.md'
       - '**.dic'
       - 'BuildVersion.xml'
+      - 'GitHub/workflows/release-build.yml'
+      - 'OneFlow/**.ps1'
 
 jobs:
   # see: https://github.com/EnricoMi/publish-unit-test-result-action?tab=readme-ov-file#support-fork-repositories-and-dependabot-branches

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -4,6 +4,7 @@ permissions:
   pages: write
   packages: write
   actions: read
+
 defaults:
   run:
     shell: pwsh

--- a/OneFlow/Publish-Release.ps1
+++ b/OneFlow/Publish-Release.ps1
@@ -19,9 +19,12 @@ using module '../PsModules/RepoBuild/RepoBuild.psd1'
 .NOTE
     For the gory details of this process see: https://www.endoflineblog.com/implementing-oneflow-on-github-bitbucket-and-gitlab
 #>
-
+[cmdletbinding(SupportsShouldProcess=$True, ConfirmImpact='High')]
 Param()
 $buildInfo = Initialize-BuildEnvironment
+
+Write-Information "Build Version XML:"
+Write-Information ((Get-ParsedBuildVersionXML -BuildInfo $buildInfo).GetEnumerator() | Sort -Property Name | Out-String)
 
 # merging the tag to develop branch on the official repository triggers the official build and release of the NuGet Packages
 $tagName = Get-BuildVersionTag $buildInfo
@@ -39,30 +42,42 @@ $mergeBackBranchName = "merge-back-$tagName"
 Write-Information 'Fetching from official repository'
 Invoke-External git fetch $officialRemoteName
 
-Write-Information "Switching to release branch [$officialReleaseBranch]"
-Invoke-External git switch '-C' $releasebranch $officialReleaseBranch
-
-$confirmation = Read-Host "Are you Sure You Want To Proceed:"
-if ($confirmation -ne 'y')
+if($PSCmdlet.ShouldProcess($officialReleaseBranch, "git switch -C $releaseBranch"))
 {
-    Write-Host "User canceled operation"
-    return
+    Write-Information "Switching to release branch [$officialReleaseBranch]"
+    Invoke-External git switch '-C' $releaseBranch $officialReleaseBranch
 }
 
-Write-Information 'Creating tag of this branch as the release'
-Invoke-External git tag $tagName '-m' "Official release: $tagName"
+if($PSCmdlet.ShouldProcess($tagName, "create annotated tag"))
+{
+    Write-Information 'Creating an annotated tag of this branch as the release'
+    Invoke-External git tag $tagName '-m' "Official release: $tagName"
+}
 
-Write-Information 'Pushing tag to official remote [Starts automated build release process]'
-Invoke-External git push $officialRemoteName '--tags'
+if($PSCmdlet.ShouldProcess($tagName, "git push $officialRemoteName tag"))
+{
+    Write-Information 'Pushing tag to official remote [Starts automated build release process]'
+    Invoke-External git push $officialRemoteName tag $tagName
+}
 
-Write-Information 'Creating local merge-back branch to merge changes associated with the release'
-# create a "merge-back" child branch to handle any updates/conflict resolutions when applying
-# the changes made in the release branch back to the develop branch.
-Invoke-External git checkout '-b' $mergeBackBranchName $releasebranch
-Write-Information 'pushing merge-back branch to fork'
-Invoke-External git push $forkRemoteName $mergeBackBranchName
+if($PSCmdlet.ShouldProcess($releasebranch, "git checkout -b $mergeBackBranchName"))
+{
+    Write-Information 'Creating local merge-back branch to merge changes associated with the release'
+    # create a "merge-back" child branch to handle any updates/conflict resolutions when applying
+    # the changes made in the release branch back to the develop branch.
+    Invoke-External git checkout '-b' $mergeBackBranchName $releasebranch
+}
 
-Write-Information 'Fast-forwarding main to tagged release'
-Invoke-External git switch '-C' $mainBranchName $officialMainBranch
-Invoke-External git merge --ff-only $tagName
-Invoke-External git push $officialRemoteName $mainBranchName
+if($PSCmdlet.ShouldProcess("$forkRemoteName $mergeBackBranchName", "git push"))
+{
+    Write-Information 'pushing merge-back branch to fork'
+    Invoke-External git push $forkRemoteName $mergeBackBranchName
+}
+
+if($PSCmdlet.ShouldProcess("$tagName", "Reset main to point to release tag"))
+{
+    Write-Information 'Updating main to point to tagged release'
+    Invoke-External git switch '-C' $mainBranchName $officialMainBranch
+    Invoke-External git reset --hard $tagName
+    Invoke-External git push --force $officialRemoteName $mainBranchName
+}

--- a/OneFlow/Start-Release.ps1
+++ b/OneFlow/Start-Release.ps1
@@ -12,8 +12,10 @@ using module '../PsModules/RepoBuild/RepoBuild.psd1'
 .DESCRIPTION
     This function creates and publishes a Release branch
 #>
-
-Param([string]$commit = "")
+[cmdletbinding(SupportsShouldProcess=$True)]
+Param(
+    [string]$commit = ""
+)
 $buildInfo = Initialize-BuildEnvironment
 
 $officialRemoteName = Get-GitRemoteName $buildInfo official
@@ -24,18 +26,24 @@ $branchName = "release/$(Get-BuildVersionTag $buildInfo)"
 Write-Information "Creating release branch in local repo"
 if ([string]::IsNullOrWhiteSpace($commit))
 {
-    Invoke-External git checkout -b $branchName
+    if($PSCmdlet.ShouldProcess($branchName, "git checkout -b"))
+    {
+        Invoke-External git checkout -b $branchName
+    }
 }
 else
 {
-    Invoke-External git checkout -b $branchName $commit
+    if($PSCmdlet.ShouldProcess("$branchName $commit", "git checkout -b"))
+    {
+        Invoke-External git checkout -b $branchName $commit
+    }
 }
-
-# push to fork so that changes go through normal PR process
-Write-Information "Pushing branch to fork"
-Invoke-External git push $forkRemoteName -u $branchName
 
 # Push to product repo so it is clear to all a release
 # is in process.
 Write-Information "Pushing branch to official repository (Push/Write permission required)"
-Invoke-External git push $officialRemoteName $branchName
+if($PSCmdlet.ShouldProcess("$officialRemoteName $branchName", "git push"))
+{
+    Invoke-External git push $officialRemoteName $branchName
+}
+


### PR DESCRIPTION
Updated automated build
* PR builds ignore some files (Still requires a review!)
    * Release build actions changes have no impact on a PR/CI build so don't trigger them
    * OneFlow script changes (also release build scripts) have no impact on PR/CI build so don't trigger them
* Added support for `ShouldProcess` to `[Start|Publish]-Release.ps1`
    - This allows safer release process by providing a mechanism to use `-WhatIf` or `-Confirm` for scripts (especially `publish-release.ps1` that have significant impact and are difficult to undo)