### PR TITLE
Fixes #83 [BUG] - BuildVersion.XML pre-release information is not considered for generated versions

### DIFF
--- a/src/Ubiquity.NET.Versioning.Build.Tasks.UT/Support/TestContextExtensions.cs
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks.UT/Support/TestContextExtensions.cs
@@ -171,7 +171,7 @@ namespace Ubiquity.NET.Versioning.Build.Tasks.UT.Support
 
             if(preReleaseFix.HasValue)
             {
-                element.Add( new XAttribute( PropertyNames.PreReleaseNumber, preReleaseFix.Value ) );
+                element.Add( new XAttribute( PropertyNames.PreReleaseFix, preReleaseFix.Value ) );
             }
 
             element.Save( strm );

--- a/src/Ubiquity.NET.Versioning.Build.Tasks/ParseBuildVersionXml.cs
+++ b/src/Ubiquity.NET.Versioning.Build.Tasks/ParseBuildVersionXml.cs
@@ -113,12 +113,6 @@ namespace Ubiquity.NET.Versioning.Build.Tasks
                     PreReleaseFix = "0";
                 }
 
-                if( PreReleaseNumber == "0" && PreReleaseFix != "0")
-                {
-                    Log.LogMessage(MessageImportance.Low, "PreReleaseNumber is 0; forcing PreReleaseFix == 0");
-                    PreReleaseFix = "0";
-                }
-
                 Log.LogMessage(MessageImportance.Low, $"-{nameof(ParseBuildVersionXml)} Task");
                 return true;
             }


### PR DESCRIPTION
Fixes #83 [BUG] - BuildVersion.XML pre-release information is not considered for generated versions
- Removed code in task that forced the Fix value to 0 if the Number was 0.
    - That was never the right thing to do. No idea where it came from.
        - Ubiquity.NET.Versioning library doesn't have this so it's unclear where it came from but it is not correct as it creates the kind of issues this fixes.