### PR TITLE
Fix casing for NuGet package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "NuGet" # See documentation for possible values
+  - package-ecosystem: "nuget" # See documentation for possible values
     directory: "/" # Location of package manifests, sadly docs are silent on the definition of "package manifests" in this context...
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Sadly the dependabot is using CASE SENSITIVE comparisons AND it assumes the ecosystem is all lower case (in contradiction to expected legal trademark forms...)