### PR TITLE
Harden OneFlow Scripts

### DIFF
--- a/OneFlow/Publish-Release.ps1
+++ b/OneFlow/Publish-Release.ps1
@@ -28,8 +28,26 @@ Write-Information ((Get-ParsedBuildVersionXML -BuildInfo $buildInfo).GetEnumerat
 
 # merging the tag to develop branch on the official repository triggers the official build and release of the NuGet Packages
 $tagName = Get-BuildVersionTag $buildInfo
+
+# This will get the name of the remote matching $buildInfo['OfficialGitRemoteUrl'])
 $officialRemoteName = Get-GitRemoteName $buildInfo official
+
+# This will get the first remote that is NOT the official repo remote URL
+# This assumes there is only one such named remote. (Usually 'origin')
 $forkRemoteName = Get-GitRemoteName $buildInfo fork
+
+if([string]::IsNullOrWhiteSpace($officialRemoteName))
+{
+    throw "Official (official) remote is not available"
+}
+
+if([string]::IsNullOrWhiteSpace($forkRemoteName))
+{
+    throw "Fork (origin) remote is not available"
+}
+
+Write-Information "Official Remote Name: $officialRemoteName"
+Write-Information "Fork Remote Name: $forkRemoteName"
 
 $releaseBranch = "release/$tagName"
 $officialReleaseBranch = "$officialRemoteName/$releaseBranch"

--- a/OneFlow/Start-Release.ps1
+++ b/OneFlow/Start-Release.ps1
@@ -18,8 +18,25 @@ Param(
 )
 $buildInfo = Initialize-BuildEnvironment
 
+# This will get the name of the remote matching $buildInfo['OfficialGitRemoteUrl'])
 $officialRemoteName = Get-GitRemoteName $buildInfo official
+
+# This will get the first remote that is NOT the official repo remote URL
+# This assumes there is only one such named remote. (Usually 'origin')
 $forkRemoteName = Get-GitRemoteName $buildInfo fork
+
+if([string]::IsNullOrWhiteSpace($officialRemoteName))
+{
+    throw "Official (official) remote is not available"
+}
+
+if([string]::IsNullOrWhiteSpace($forkRemoteName))
+{
+    throw "Fork (origin) remote is not available"
+}
+
+Write-Information "Official Remote Name: $officialRemoteName"
+Write-Information "Fork Remote Name: $forkRemoteName"
 
 # create new local branch for the release
 $branchName = "release/$(Get-BuildVersionTag $buildInfo)"


### PR DESCRIPTION
Harden OneFlow Scripts
Fixes #93
* Updates OneFlow scripts to validate BOTH remotes are present in the set of remotes known to git.
    - For normal GitHub use only 'origin' is set upon first clone, so a second (official) needs to be added manually. This is easy to ommit when first setting up a new machine. These scripts will now catch that.