### PR TITLE
Removes diagnostics from New-GeneratedVersionProps.ps1

### DIFF
--- a/New-GeneratedVersionProps.ps1
+++ b/New-GeneratedVersionProps.ps1
@@ -360,20 +360,6 @@ try
     # [Been there, done that, worn out the bloody T-Shirt...]
     $csemVer = [CSemVer]::New($verInfo)
 
-    #<DIAGNOSTIC>
-    Write-Verbose "CSemVer:"
-    Write-Verbose ($csemVer | Out-String)
-    if($csemVer.PreReleaseVersion)
-    {
-        Write-Verbose "PreRelease:"
-        Write-Verbose ($csemVer.PreReleaseVersion | Out-String)
-    }
-    Write-Verbose "PreReleaseVersion.ToString($true): $($csemVer.PreReleaseVersion.ToString($true))"
-    Write-Verbose "PreReleaseVersion.ToString($false): $($csemVer.PreReleaseVersion.ToString($false))"
-    Write-Verbose "ToString($true): $($csemVer.ToString($true))"
-    Write-Verbose "ToString($false): $($csemVer.ToString($false))"
-    #</DIAGNOSTIC>
-
     $xmlDoc = [System.Xml.XmlDocument]::new()
     $projectElement = $xmlDoc.CreateElement('Project')
     $xmlDoc.AppendChild($projectElement) | Out-Null


### PR DESCRIPTION
Removes diagnostics from New-GeneratedVersionProps.ps1

* This just removes the somewhat sloppy verbose diagnostics that assumed a prerelease version even exists (it might not)